### PR TITLE
Enable APQ in Relay GraphQL transport

### DIFF
--- a/web/src/environment.test.ts
+++ b/web/src/environment.test.ts
@@ -1,0 +1,152 @@
+import { createHash, webcrypto } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ky from 'ky'
+import type { RequestParameters } from 'relay-runtime'
+import { fetchGraphQL } from './environment'
+
+vi.mock('./env', () => ({
+  env: { VITE_SERVER_URL: 'https://api.example.test' },
+}))
+vi.mock('ky', () => ({ default: { post: vi.fn() } }))
+
+const request: RequestParameters = {
+  name: 'TestQuery',
+  operationKind: 'query',
+  text: 'query TestQuery { __typename }',
+  id: null,
+  cacheID: 'relay-cache-id-is-not-a-sha256-hash',
+  metadata: {},
+}
+const miss = {
+  data: null,
+  errors: [
+    {
+      message: 'PersistedQueryNotFound',
+      extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' },
+    },
+  ],
+}
+const success = { data: { __typename: 'Query' } }
+const post = vi.mocked(ky.post)
+const respond = (body: object) =>
+  post.mockReturnValueOnce({ json: async () => body } as ReturnType<
+    typeof ky.post
+  >)
+const run = (operation = request) => fetchGraphQL(operation, { id: 42 }, {})
+
+beforeEach(() => {
+  post.mockReset()
+  vi.stubGlobal('crypto', webcrypto)
+  const values: Record<string, string> = {
+    token: 'test-token',
+    householdId: '7',
+    displayCurrencyId: '9',
+  }
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => values[key] ?? null,
+  })
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('Relay automatic persisted queries', () => {
+  it('sends the SHA-256 hash without query text on a cache hit', async () => {
+    respond(success)
+    expect(await run()).toEqual(success)
+    expect(post).toHaveBeenCalledExactlyOnceWith(
+      'https://api.example.test/query',
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+          'X-Household-ID': '7',
+          'X-Display-Currency-ID': '9',
+        },
+        json: {
+          operationName: request.name,
+          variables: { id: 42 },
+          extensions: {
+            persistedQuery: {
+              version: 1,
+              sha256Hash: createHash('sha256')
+                .update(request.text!)
+                .digest('hex'),
+            },
+          },
+        },
+      },
+    )
+  })
+
+  it('registers the full query once on a miss and returns to hash-only requests', async () => {
+    respond(miss)
+    respond(success)
+    respond(success)
+    expect(await run()).toEqual(success)
+    const first = post.mock.calls[0][1]!
+    expect(post.mock.calls[1][1]).toEqual({
+      ...first,
+      json: { ...first.json!, query: request.text },
+    })
+    expect(await run()).toEqual(success)
+    expect(post.mock.calls[2][1]).toEqual(first)
+    expect(post).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not loop if registration also returns a cache miss', async () => {
+    respond(miss)
+    respond(miss)
+    expect(await run()).toEqual(miss)
+    expect(post).toHaveBeenCalledTimes(2)
+  })
+
+  it('supports the same handshake for mutations', async () => {
+    respond(miss)
+    respond(success)
+    const mutation: RequestParameters = {
+      ...request,
+      name: 'TestMutation',
+      operationKind: 'mutation',
+      text: 'mutation TestMutation { doSomething }',
+    }
+    await run(mutation)
+    expect(post.mock.calls[1][1]?.json).toMatchObject({
+      operationName: mutation.name,
+      query: mutation.text,
+    })
+    expect(post).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    { errors: [{ message: 'Forbidden', extensions: { code: 'FORBIDDEN' } }] },
+    { data: { result: null }, errors: miss.errors },
+  ])(
+    'does not retry execution errors or responses with data: %j',
+    async (body) => {
+      respond(body)
+      expect(await run()).toEqual(body)
+      expect(post).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it('propagates HTTP errors without retrying the operation', async () => {
+    post.mockReturnValueOnce({
+      json: async (): Promise<object> => {
+        throw new Error('Unauthorized')
+      },
+    } as ReturnType<typeof ky.post>)
+    await expect(run()).rejects.toThrow('Unauthorized')
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends ordinary queries when Web Crypto is unavailable', async () => {
+    vi.stubGlobal('crypto', undefined)
+    respond(success)
+    await run()
+    expect(post.mock.calls[0][1]?.json).toEqual({
+      query: request.text,
+      operationName: request.name,
+      variables: { id: 42 },
+    })
+  })
+})

--- a/web/src/environment.ts
+++ b/web/src/environment.ts
@@ -10,27 +10,57 @@ import ky from 'ky'
 
 const HTTP_ENDPOINT = env.VITE_SERVER_URL
 
-const fetchGraphQL: FetchFunction = async (request, variables) => {
+export const fetchGraphQL: FetchFunction = async (request, variables) => {
+  const query = request.text
+  if (!query) throw new Error('GraphQL operation text is required for APQ')
+
   const token = localStorage.getItem(LOCAL_STORAGE_TOKEN_KEY)
   const householdId = localStorage.getItem(LOCAL_STORAGE_HOUSEHOLD_ID_KEY)
   const displayCurrencyId = localStorage.getItem(
     LOCAL_STORAGE_DISPLAY_CURRENCY_ID_KEY,
   )
 
-  const resp = await ky
-    .post(HTTP_ENDPOINT + '/query', {
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        ...(householdId ? { 'X-Household-ID': householdId } : {}),
-        ...(displayCurrencyId
-          ? { 'X-Display-Currency-ID': displayCurrencyId }
-          : {}),
-      },
-      json: { query: request.text, variables },
-    })
-    .json<GraphQLResponse>()
-  return resp
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(householdId ? { 'X-Household-ID': householdId } : {}),
+    ...(displayCurrencyId
+      ? { 'X-Display-Currency-ID': displayCurrencyId }
+      : {}),
+  }
+  const send = (json: object) =>
+    ky.post(HTTP_ENDPOINT + '/query', { headers, json }).json<GraphQLResponse>()
+  const operation = { operationName: request.name, variables }
+
+  // Web Crypto is unavailable on insecure origins (for example, LAN dev URLs).
+  if (!globalThis.crypto?.subtle) return send({ ...operation, query })
+
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(query),
+  )
+  const sha256Hash = Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('')
+  const extensions = { persistedQuery: { version: 1, sha256Hash } }
+  const response = await send({ ...operation, extensions })
+
+  // Retry only a pre-execution cache miss, never an operation execution error.
+  if (
+    (!('data' in response) || response.data === null) &&
+    'errors' in response &&
+    response.errors?.some(
+      (error) =>
+        'extensions' in error &&
+        error.extensions !== null &&
+        typeof error.extensions === 'object' &&
+        'code' in error.extensions &&
+        error.extensions.code === 'PERSISTED_QUERY_NOT_FOUND',
+    )
+  ) {
+    return send({ ...operation, extensions, query })
+  }
+  return response
 }
 
 export const environment = new Environment({


### PR DESCRIPTION
The server already enables APQ through gqlgen v0.17.86's `handler.NewDefaultServer`, but Relay sends the full GraphQL document on every request. This change enables APQ in the Relay transport: send the SHA-256 hash first, then retry once with the document when gqlgen returns `PERSISTED_QUERY_NOT_FOUND` (including its `data: null` response).

Both requests preserve the operation name, variables, authentication, household, and display-currency headers. Other errors are returned without an application retry. Origins without Web Crypto continue using ordinary full-document requests. The existing bounded server cache remains in use; cache eviction or a server restart is handled by the registration handshake.

Validation:
- All 37 frontend tests pass, including eight APQ cases covering cache hits, registration, subsequent hash-only requests, mutation negotiation, error propagation, and Web Crypto fallback.
- TypeScript, ESLint, and Prettier checks pass.
- Vite production build passes (existing large-chunk warning).
- An HTTP recorder smoke test against the project's schema and gqlgen default handler verifies miss → registration → hash-only hit, all HTTP 200.

Closes #243.
