### PR TITLE
feat(accounts): restore archived accounts from settings

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -333,6 +333,7 @@ type ComplexityRoot struct {
 		Refresh                     func(childComplexity int) int
 		RemoveHouseholdUser         func(childComplexity int, id int) int
 		SellInvestment              func(childComplexity int, input model.SellInvestmentInputCustom) int
+		UnarchiveAccount            func(childComplexity int, id int) int
 		UpdateAccount               func(childComplexity int, id int, input ent.UpdateAccountInput) int
 		UpdateHousehold             func(childComplexity int, id int, input ent.UpdateHouseholdInput) int
 		UpdateHouseholdCurrency     func(childComplexity int, id int, input ent.UpdateHouseholdCurrencyInput) int
@@ -644,6 +645,7 @@ type MutationResolver interface {
 	UpdateAccount(ctx context.Context, id int, input ent.UpdateAccountInput) (*ent.AccountEdge, error)
 	DeleteAccount(ctx context.Context, id int) (*model.DeleteAccountPayload, error)
 	ArchiveAccount(ctx context.Context, id int) (bool, error)
+	UnarchiveAccount(ctx context.Context, id int) (*ent.Account, error)
 	CreateInvestment(ctx context.Context, input model.CreateInvestmentInputCustom) (*ent.InvestmentEdge, error)
 	CreateTransactionCategory(ctx context.Context, input ent.CreateTransactionCategoryInput) (*ent.TransactionCategoryEdge, error)
 	UpdateTransactionCategory(ctx context.Context, id int, input ent.UpdateTransactionCategoryInput) (*ent.TransactionCategoryEdge, error)
@@ -2118,6 +2120,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.SellInvestment(childComplexity, args["input"].(model.SellInvestmentInputCustom)), true
+	case "Mutation.unarchiveAccount":
+		if e.complexity.Mutation.UnarchiveAccount == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_unarchiveAccount_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UnarchiveAccount(childComplexity, args["id"].(int)), true
 	case "Mutation.updateAccount":
 		if e.complexity.Mutation.UpdateAccount == nil {
 			break
@@ -4168,6 +4181,17 @@ func (ec *executionContext) field_Mutation_sellInvestment_args(ctx context.Conte
 		return nil, err
 	}
 	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_unarchiveAccount_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalNID2int)
+	if err != nil {
+		return nil, err
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -10860,6 +10884,85 @@ func (ec *executionContext) fieldContext_Mutation_archiveAccount(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_archiveAccount_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_unarchiveAccount(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_unarchiveAccount,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().UnarchiveAccount(ctx, fc.Args["id"].(int))
+		},
+		nil,
+		ec.marshalNAccount2ᚖbeavermoneyᚗappᚋentᚐAccount,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_unarchiveAccount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Account_id(ctx, field)
+			case "createTime":
+				return ec.fieldContext_Account_createTime(ctx, field)
+			case "updateTime":
+				return ec.fieldContext_Account_updateTime(ctx, field)
+			case "householdID":
+				return ec.fieldContext_Account_householdID(ctx, field)
+			case "name":
+				return ec.fieldContext_Account_name(ctx, field)
+			case "type":
+				return ec.fieldContext_Account_type(ctx, field)
+			case "balance":
+				return ec.fieldContext_Account_balance(ctx, field)
+			case "category":
+				return ec.fieldContext_Account_category(ctx, field)
+			case "icon":
+				return ec.fieldContext_Account_icon(ctx, field)
+			case "value":
+				return ec.fieldContext_Account_value(ctx, field)
+			case "householdCurrencyID":
+				return ec.fieldContext_Account_householdCurrencyID(ctx, field)
+			case "userID":
+				return ec.fieldContext_Account_userID(ctx, field)
+			case "archived":
+				return ec.fieldContext_Account_archived(ctx, field)
+			case "household":
+				return ec.fieldContext_Account_household(ctx, field)
+			case "householdCurrency":
+				return ec.fieldContext_Account_householdCurrency(ctx, field)
+			case "user":
+				return ec.fieldContext_Account_user(ctx, field)
+			case "transactionEntries":
+				return ec.fieldContext_Account_transactionEntries(ctx, field)
+			case "investments":
+				return ec.fieldContext_Account_investments(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Account", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_unarchiveAccount_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -34373,6 +34476,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "unarchiveAccount":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_unarchiveAccount(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "createInvestment":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createInvestment(ctx, field)
@@ -38371,6 +38481,10 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 // endregion **************************** object.gotpl ****************************
 
 // region    ***************************** type.gotpl *****************************
+
+func (ec *executionContext) marshalNAccount2beavermoneyᚗappᚋentᚐAccount(ctx context.Context, sel ast.SelectionSet, v ent.Account) graphql.Marshaler {
+	return ec._Account(ctx, sel, &v)
+}
 
 func (ec *executionContext) marshalNAccount2ᚖbeavermoneyᚗappᚋentᚐAccount(ctx context.Context, sel ast.SelectionSet, v *ent.Account) graphql.Marshaler {
 	if v == nil {

--- a/gql/mutation.graphql
+++ b/gql/mutation.graphql
@@ -7,6 +7,7 @@ type Mutation {
   updateAccount(id: ID!, input: UpdateAccountInput!): AccountEdge!
   deleteAccount(id: ID!): DeleteAccountPayload!
   archiveAccount(id: ID!): Boolean!
+  unarchiveAccount(id: ID!): Account!
 
   createInvestment(input: CreateInvestmentInputCustom!): InvestmentEdge!
 

--- a/gql/mutation.resolvers.go
+++ b/gql/mutation.resolvers.go
@@ -484,6 +484,19 @@ func (r *mutationResolver) ArchiveAccount(ctx context.Context, id int) (bool, er
 	return true, nil
 }
 
+// UnarchiveAccount is the resolver for the unarchiveAccount field.
+func (r *mutationResolver) UnarchiveAccount(ctx context.Context, id int) (*ent.Account, error) {
+	ctx, span := r.tracer.Start(ctx, "mutationResolver.UnarchiveAccount",
+		trace.WithAttributes(
+			attribute.Int("householdID", contextkeys.GetHouseholdID(ctx)),
+			attribute.Int("userID", contextkeys.GetUserID(ctx)),
+		),
+	)
+	defer span.End()
+
+	return ent.FromContext(ctx).Account.UpdateOneID(id).SetArchived(false).Save(ctx)
+}
+
 // CreateInvestment is the resolver for the createInvestment field.
 func (r *mutationResolver) CreateInvestment(ctx context.Context, input model.CreateInvestmentInputCustom) (*ent.InvestmentEdge, error) {
 	userID := contextkeys.GetUserID(ctx)

--- a/gql/mutation_resolvers_account_test.go
+++ b/gql/mutation_resolvers_account_test.go
@@ -1,0 +1,67 @@
+package gql
+
+import (
+	"context"
+	"testing"
+
+	"beavermoney.app/ent/account"
+	"beavermoney.app/internal/contextkeys"
+)
+
+func TestUnarchiveAccount(t *testing.T) {
+	f := setupMemberFixture(t)
+	ctx := memberCallCtx(f.client, f.adminUser.ID, f.household.ID)
+	acc := f.client.Account.Create().
+		SetName("Old savings").SetType(account.TypeLiquidity).
+		SetHouseholdID(f.household.ID).SetUserID(f.adminUser.ID).
+		SetHouseholdCurrencyID(f.primaryCurrency.ID).SetArchived(true).SaveX(ctx)
+	mr := &mutationResolver{Resolver: newMemberTestResolver(f.client)}
+
+	for range 2 {
+		restored, err := mr.UnarchiveAccount(ctx, acc.ID)
+		if err != nil {
+			t.Fatalf("unarchive account: %v", err)
+		}
+		if restored.Archived || restored.ID != acc.ID || restored.Name != acc.Name ||
+			!restored.Balance.Equal(acc.Balance) || !restored.Value.Equal(acc.Value) {
+			t.Fatalf("unarchive changed account data or left it archived: %+v", restored)
+		}
+	}
+	if f.client.Account.GetX(ctx, acc.ID).Archived {
+		t.Fatal("account is still archived in storage")
+	}
+}
+
+func TestUnarchiveAccountRejectsOtherHousehold(t *testing.T) {
+	f := setupMemberFixture(t)
+	otherCtx := memberCallCtx(f.client, f.adminUser.ID, f.otherHousehold.ID)
+	acc := f.client.Account.Create().
+		SetName("Other household savings").SetType(account.TypeLiquidity).
+		SetHouseholdID(f.otherHousehold.ID).SetUserID(f.adminUser.ID).
+		SetHouseholdCurrencyID(f.otherCurrency.ID).SetArchived(true).SaveX(otherCtx)
+	mr := &mutationResolver{Resolver: newMemberTestResolver(f.client)}
+	ctx := memberCallCtx(f.client, f.adminUser.ID, f.household.ID)
+	if _, err := mr.UnarchiveAccount(ctx, acc.ID); err == nil {
+		t.Fatal("expected household isolation to reject restore")
+	}
+	if !f.client.Account.GetX(otherCtx, acc.ID).Archived {
+		t.Fatal("account in other household was changed")
+	}
+}
+
+func TestUnarchiveAccountRejectsMissingContextAndAccount(t *testing.T) {
+	f := setupMemberFixture(t)
+	mr := &mutationResolver{Resolver: newMemberTestResolver(f.client)}
+	ctx := memberCallCtx(f.client, f.adminUser.ID, f.household.ID)
+	if _, err := mr.UnarchiveAccount(ctx, 999999); err == nil {
+		t.Fatal("expected missing account error")
+	}
+	acc := f.client.Account.Create().
+		SetName("Archived").SetType(account.TypeLiquidity).
+		SetHouseholdID(f.household.ID).SetUserID(f.adminUser.ID).
+		SetHouseholdCurrencyID(f.primaryCurrency.ID).SetArchived(true).SaveX(ctx)
+	ctx = context.WithValue(ctx, contextkeys.HouseholdIDKey(), 0)
+	if _, err := mr.UnarchiveAccount(ctx, acc.ID); err == nil {
+		t.Fatal("expected missing household context error")
+	}
+}

--- a/relay.graphql
+++ b/relay.graphql
@@ -3444,6 +3444,7 @@ type Mutation {
   updateAccount(id: ID!, input: UpdateAccountInput!): AccountEdge!
   deleteAccount(id: ID!): DeleteAccountPayload!
   archiveAccount(id: ID!): Boolean!
+  unarchiveAccount(id: ID!): Account!
   createInvestment(input: CreateInvestmentInputCustom!): InvestmentEdge!
   createTransactionCategory(
     input: CreateTransactionCategoryInput!

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as UserHouseholdHouseholdIdSubscriptionsNewRouteImport } from './
 import { Route as UserHouseholdHouseholdIdSubscriptionsSubscriptionIdRouteImport } from './routes/_user/household/$householdId/subscriptions/$subscriptionId'
 import { Route as UserHouseholdHouseholdIdSettingsMembersRouteImport } from './routes/_user/household/$householdId/settings/members'
 import { Route as UserHouseholdHouseholdIdSettingsGeneralRouteImport } from './routes/_user/household/$householdId/settings/general'
+import { Route as UserHouseholdHouseholdIdSettingsAccountsRouteImport } from './routes/_user/household/$householdId/settings/accounts'
 import { Route as UserHouseholdHouseholdIdInvestmentsNewRouteImport } from './routes/_user/household/$householdId/investments/new'
 import { Route as UserHouseholdHouseholdIdInvestmentsInvestmentIdRouteImport } from './routes/_user/household/$householdId/investments/$investmentId'
 import { Route as UserHouseholdHouseholdIdCategoriesNewRouteImport } from './routes/_user/household/$householdId/categories/new'
@@ -187,6 +188,12 @@ const UserHouseholdHouseholdIdSettingsGeneralRoute =
     path: '/general',
     getParentRoute: () => UserHouseholdHouseholdIdSettingsRouteRoute,
   } as any)
+const UserHouseholdHouseholdIdSettingsAccountsRoute =
+  UserHouseholdHouseholdIdSettingsAccountsRouteImport.update({
+    id: '/accounts',
+    path: '/accounts',
+    getParentRoute: () => UserHouseholdHouseholdIdSettingsRouteRoute,
+  } as any)
 const UserHouseholdHouseholdIdInvestmentsNewRoute =
   UserHouseholdHouseholdIdInvestmentsNewRouteImport.update({
     id: '/new',
@@ -257,6 +264,7 @@ export interface FileRoutesByFullPath {
   '/household/$householdId/categories/new': typeof UserHouseholdHouseholdIdCategoriesNewRoute
   '/household/$householdId/investments/$investmentId': typeof UserHouseholdHouseholdIdInvestmentsInvestmentIdRoute
   '/household/$householdId/investments/new': typeof UserHouseholdHouseholdIdInvestmentsNewRoute
+  '/household/$householdId/settings/accounts': typeof UserHouseholdHouseholdIdSettingsAccountsRoute
   '/household/$householdId/settings/general': typeof UserHouseholdHouseholdIdSettingsGeneralRoute
   '/household/$householdId/settings/members': typeof UserHouseholdHouseholdIdSettingsMembersRoute
   '/household/$householdId/subscriptions/$subscriptionId': typeof UserHouseholdHouseholdIdSubscriptionsSubscriptionIdRoute
@@ -283,6 +291,7 @@ export interface FileRoutesByTo {
   '/household/$householdId/categories/new': typeof UserHouseholdHouseholdIdCategoriesNewRoute
   '/household/$householdId/investments/$investmentId': typeof UserHouseholdHouseholdIdInvestmentsInvestmentIdRoute
   '/household/$householdId/investments/new': typeof UserHouseholdHouseholdIdInvestmentsNewRoute
+  '/household/$householdId/settings/accounts': typeof UserHouseholdHouseholdIdSettingsAccountsRoute
   '/household/$householdId/settings/general': typeof UserHouseholdHouseholdIdSettingsGeneralRoute
   '/household/$householdId/settings/members': typeof UserHouseholdHouseholdIdSettingsMembersRoute
   '/household/$householdId/subscriptions/$subscriptionId': typeof UserHouseholdHouseholdIdSubscriptionsSubscriptionIdRoute
@@ -319,6 +328,7 @@ export interface FileRoutesById {
   '/_user/household/$householdId/categories/new': typeof UserHouseholdHouseholdIdCategoriesNewRoute
   '/_user/household/$householdId/investments/$investmentId': typeof UserHouseholdHouseholdIdInvestmentsInvestmentIdRoute
   '/_user/household/$householdId/investments/new': typeof UserHouseholdHouseholdIdInvestmentsNewRoute
+  '/_user/household/$householdId/settings/accounts': typeof UserHouseholdHouseholdIdSettingsAccountsRoute
   '/_user/household/$householdId/settings/general': typeof UserHouseholdHouseholdIdSettingsGeneralRoute
   '/_user/household/$householdId/settings/members': typeof UserHouseholdHouseholdIdSettingsMembersRoute
   '/_user/household/$householdId/subscriptions/$subscriptionId': typeof UserHouseholdHouseholdIdSubscriptionsSubscriptionIdRoute
@@ -356,6 +366,7 @@ export interface FileRouteTypes {
     | '/household/$householdId/categories/new'
     | '/household/$householdId/investments/$investmentId'
     | '/household/$householdId/investments/new'
+    | '/household/$householdId/settings/accounts'
     | '/household/$householdId/settings/general'
     | '/household/$householdId/settings/members'
     | '/household/$householdId/subscriptions/$subscriptionId'
@@ -382,6 +393,7 @@ export interface FileRouteTypes {
     | '/household/$householdId/categories/new'
     | '/household/$householdId/investments/$investmentId'
     | '/household/$householdId/investments/new'
+    | '/household/$householdId/settings/accounts'
     | '/household/$householdId/settings/general'
     | '/household/$householdId/settings/members'
     | '/household/$householdId/subscriptions/$subscriptionId'
@@ -417,6 +429,7 @@ export interface FileRouteTypes {
     | '/_user/household/$householdId/categories/new'
     | '/_user/household/$householdId/investments/$investmentId'
     | '/_user/household/$householdId/investments/new'
+    | '/_user/household/$householdId/settings/accounts'
     | '/_user/household/$householdId/settings/general'
     | '/_user/household/$householdId/settings/members'
     | '/_user/household/$householdId/subscriptions/$subscriptionId'
@@ -616,6 +629,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserHouseholdHouseholdIdSettingsGeneralRouteImport
       parentRoute: typeof UserHouseholdHouseholdIdSettingsRouteRoute
     }
+    '/_user/household/$householdId/settings/accounts': {
+      id: '/_user/household/$householdId/settings/accounts'
+      path: '/accounts'
+      fullPath: '/household/$householdId/settings/accounts'
+      preLoaderRoute: typeof UserHouseholdHouseholdIdSettingsAccountsRouteImport
+      parentRoute: typeof UserHouseholdHouseholdIdSettingsRouteRoute
+    }
     '/_user/household/$householdId/investments/new': {
       id: '/_user/household/$householdId/investments/new'
       path: '/new'
@@ -757,6 +777,7 @@ const UserHouseholdHouseholdIdInvestmentsRouteRouteWithChildren =
   )
 
 interface UserHouseholdHouseholdIdSettingsRouteRouteChildren {
+  UserHouseholdHouseholdIdSettingsAccountsRoute: typeof UserHouseholdHouseholdIdSettingsAccountsRoute
   UserHouseholdHouseholdIdSettingsGeneralRoute: typeof UserHouseholdHouseholdIdSettingsGeneralRoute
   UserHouseholdHouseholdIdSettingsMembersRoute: typeof UserHouseholdHouseholdIdSettingsMembersRoute
   UserHouseholdHouseholdIdSettingsIndexRoute: typeof UserHouseholdHouseholdIdSettingsIndexRoute
@@ -764,6 +785,8 @@ interface UserHouseholdHouseholdIdSettingsRouteRouteChildren {
 
 const UserHouseholdHouseholdIdSettingsRouteRouteChildren: UserHouseholdHouseholdIdSettingsRouteRouteChildren =
   {
+    UserHouseholdHouseholdIdSettingsAccountsRoute:
+      UserHouseholdHouseholdIdSettingsAccountsRoute,
     UserHouseholdHouseholdIdSettingsGeneralRoute:
       UserHouseholdHouseholdIdSettingsGeneralRoute,
     UserHouseholdHouseholdIdSettingsMembersRoute:

--- a/web/src/routes/_user/household/$householdId/accounts/$accountId/route.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/$accountId/route.tsx
@@ -302,7 +302,8 @@ function RouteComponent() {
               <AlertDialogTitle>Archive Account</AlertDialogTitle>
               <AlertDialogDescription>
                 This will archive the account and hide it from the main list.
-                Archive is only allowed when the account value is zero.
+                Archive is only allowed when the account value is zero. You can
+                unarchive it later in Settings → Accounts.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/web/src/routes/_user/household/$householdId/settings/-components/__generated__/accountSettingsFragment.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/settings/-components/__generated__/accountSettingsFragment.graphql.ts
@@ -1,0 +1,153 @@
+/**
+ * @generated SignedSource<<8e71a58be137fba79be5d1fe84f0209d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type AccountType = "investment" | "liability" | "liquidity" | "property" | "receivable" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type accountSettingsFragment$data = {
+  readonly accounts: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly archived: boolean;
+        readonly householdCurrency: {
+          readonly code: string;
+        };
+        readonly id: string;
+        readonly name: string;
+        readonly type: AccountType;
+        readonly user: {
+          readonly name: string;
+        };
+      } | null | undefined;
+    } | null | undefined> | null | undefined;
+  };
+  readonly " $fragmentType": "accountSettingsFragment";
+};
+export type accountSettingsFragment$key = {
+  readonly " $data"?: accountSettingsFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"accountSettingsFragment">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "accountSettingsFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "where",
+          "value": {
+            "archived": true
+          }
+        }
+      ],
+      "concreteType": "AccountConnection",
+      "kind": "LinkedField",
+      "name": "accounts",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AccountEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Account",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "type",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "archived",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "User",
+                  "kind": "LinkedField",
+                  "name": "user",
+                  "plural": false,
+                  "selections": [
+                    (v0/*: any*/)
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "HouseholdCurrency",
+                  "kind": "LinkedField",
+                  "name": "householdCurrency",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "code",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "accounts(where:{\"archived\":true})"
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "5e3831bbfbe3cd6147ba158aabbe5000";
+
+export default node;

--- a/web/src/routes/_user/household/$householdId/settings/-components/__generated__/accountSettingsUnarchiveMutation.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/settings/-components/__generated__/accountSettingsUnarchiveMutation.graphql.ts
@@ -1,0 +1,97 @@
+/**
+ * @generated SignedSource<<d64e07bfccc27254967e62039b335f60>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type accountSettingsUnarchiveMutation$variables = {
+  id: string;
+};
+export type accountSettingsUnarchiveMutation$data = {
+  readonly unarchiveAccount: {
+    readonly archived: boolean;
+    readonly id: string;
+  };
+};
+export type accountSettingsUnarchiveMutation = {
+  response: accountSettingsUnarchiveMutation$data;
+  variables: accountSettingsUnarchiveMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      }
+    ],
+    "concreteType": "Account",
+    "kind": "LinkedField",
+    "name": "unarchiveAccount",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "archived",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "accountSettingsUnarchiveMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "accountSettingsUnarchiveMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "88c9deb2a41c19771bb081b425f4bab6",
+    "id": null,
+    "metadata": {},
+    "name": "accountSettingsUnarchiveMutation",
+    "operationKind": "mutation",
+    "text": "mutation accountSettingsUnarchiveMutation(\n  $id: ID!\n) {\n  unarchiveAccount(id: $id) {\n    id\n    archived\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "81da19057eac15639bdcfe07f6488590";
+
+export default node;

--- a/web/src/routes/_user/household/$householdId/settings/-components/account-settings.test.tsx
+++ b/web/src/routes/_user/household/$householdId/settings/-components/account-settings.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { Suspense } from 'react'
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RelayEnvironmentProvider, useLazyLoadQuery } from 'react-relay'
+import {
+  Environment,
+  Network,
+  Observable,
+  RecordSource,
+  Store,
+} from 'relay-runtime'
+import type { GraphQLResponse } from 'relay-runtime'
+import query from '../__generated__/accountsSettingsQuery.graphql'
+import type { accountsSettingsQuery } from '../__generated__/accountsSettingsQuery.graphql'
+import { AccountSettings } from './account-settings'
+
+vi.mock('@/hooks/use-household', () => ({
+  useHousehold: () => ({ household: { id: 'household-1', locale: 'en-US' } }),
+}))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+afterEach(cleanup)
+
+function setup(hasAccounts = true) {
+  let mutationSink:
+    | {
+        next: (response: GraphQLResponse) => void
+        complete: () => void
+        error: (error: Error) => void
+      }
+    | undefined
+  const environment = new Environment({
+    store: new Store(new RecordSource()),
+    network: Network.create((operation) => {
+      if (operation.operationKind === 'mutation') {
+        return Observable.create((sink) => {
+          mutationSink = sink
+        })
+      }
+      return Observable.from({
+        data: {
+          household: { id: 'household-1' },
+          accounts: {
+            edges: hasAccounts
+              ? [
+                  {
+                    node: {
+                      id: 'account-1',
+                      name: 'Old savings',
+                      type: 'liquidity',
+                      archived: true,
+                      user: { id: 'user-1', name: 'Joey' },
+                      householdCurrency: { id: 'currency-1', code: 'CAD' },
+                    },
+                  },
+                ]
+              : [],
+          },
+        },
+      })
+    }),
+  })
+  function Harness() {
+    const data = useLazyLoadQuery<accountsSettingsQuery>(query, {})
+    return <AccountSettings fragmentRef={data} />
+  }
+  render(
+    <RelayEnvironmentProvider environment={environment}>
+      <Suspense fallback="Loading">
+        <Harness />
+      </Suspense>
+    </RelayEnvironmentProvider>,
+  )
+  return {
+    succeed: () =>
+      act(() => {
+        mutationSink?.next({
+          data: { unarchiveAccount: { id: 'account-1', archived: false } },
+        })
+        mutationSink?.complete()
+      }),
+    fail: () =>
+      act(() => {
+        mutationSink?.error(new Error('Offline'))
+      }),
+  }
+}
+
+describe('Account settings', () => {
+  it('restores an account and removes it from the archive without a reload', async () => {
+    const request = setup()
+    const button = await screen.findByRole('button', {
+      name: 'Unarchive Old savings',
+    })
+    fireEvent.click(button)
+    expect(button.hasAttribute('disabled')).toBe(true)
+    expect(screen.getByText('Unarchiving…')).toBeTruthy()
+    request.succeed()
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Unarchive Old savings' }),
+      ).toBeNull(),
+    )
+    expect(screen.getByText('No archived accounts')).toBeTruthy()
+    await waitFor(() =>
+      expect(screen.getByRole('status').textContent).toContain(
+        'Old savings is active again',
+      ),
+    )
+  })
+
+  it('keeps the account available to retry after a failed mutation', async () => {
+    const request = setup()
+    const button = await screen.findByRole('button', {
+      name: 'Unarchive Old savings',
+    })
+    fireEvent.click(button)
+    request.fail()
+    await waitFor(() => expect(button.hasAttribute('disabled')).toBe(false))
+    expect(screen.getByText('Old savings')).toBeTruthy()
+  })
+
+  it('explains the empty archive', async () => {
+    setup(false)
+    expect(await screen.findByText('No archived accounts')).toBeTruthy()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})

--- a/web/src/routes/_user/household/$householdId/settings/-components/account-settings.tsx
+++ b/web/src/routes/_user/household/$householdId/settings/-components/account-settings.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react'
+import { graphql, useFragment, useMutation } from 'react-relay'
+import { Archive, ArchiveRestore } from 'lucide-react'
+import { toast } from 'sonner'
+import type { accountSettingsFragment$key } from './__generated__/accountSettingsFragment.graphql'
+import type { accountSettingsUnarchiveMutation } from './__generated__/accountSettingsUnarchiveMutation.graphql'
+import { Button } from '@/components/ui/button'
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty'
+import { useHousehold } from '@/hooks/use-household'
+import { commitMutationResult } from '@/lib/relay'
+
+const fragment = graphql`
+  fragment accountSettingsFragment on Query {
+    accounts(where: { archived: true }) {
+      edges {
+        node {
+          id
+          name
+          type
+          archived
+          user {
+            name
+          }
+          householdCurrency {
+            code
+          }
+        }
+      }
+    }
+  }
+`
+
+const mutation = graphql`
+  mutation accountSettingsUnarchiveMutation($id: ID!) {
+    unarchiveAccount(id: $id) {
+      id
+      archived
+    }
+  }
+`
+
+export function AccountSettings({
+  fragmentRef,
+}: {
+  fragmentRef: accountSettingsFragment$key
+}) {
+  const data = useFragment(fragment, fragmentRef)
+  const { household } = useHousehold()
+  const [commit, isInFlight] =
+    useMutation<accountSettingsUnarchiveMutation>(mutation)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [feedback, setFeedback] = useState('')
+  const accounts = (data.accounts.edges ?? [])
+    .flatMap((edge) => (edge?.node?.archived ? [edge.node] : []))
+    .sort((a, b) => a.name.localeCompare(b.name, household.locale))
+
+  async function unarchive(id: string, name: string) {
+    setPendingId(id)
+    setFeedback('')
+    const result = await commitMutationResult<accountSettingsUnarchiveMutation>(
+      commit,
+      {
+        variables: { id },
+        updater: (store) => store.get(household.id)?.invalidateRecord(),
+      },
+    )
+    setPendingId(null)
+    if (result.status === 'error') {
+      toast.error(`Could not unarchive ${name}. Please try again.`)
+      return
+    }
+    setFeedback(`${name} is active again. You can find it in Accounts.`)
+    toast.success(`${name} unarchived.`)
+  }
+
+  return (
+    <section
+      className="flex min-w-0 flex-col gap-5"
+      aria-labelledby="account-settings-title"
+    >
+      <header className="flex flex-col gap-1">
+        <h1
+          id="account-settings-title"
+          className="text-lg font-semibold tracking-tight"
+        >
+          Account settings
+        </h1>
+        <p className="text-muted-foreground text-xs/relaxed">
+          Bring archived accounts back into your ledger.
+        </p>
+      </header>
+      <section
+        aria-labelledby="archived-accounts-title"
+        className="flex flex-col gap-3"
+      >
+        <div className="flex flex-col gap-1">
+          <h2 id="archived-accounts-title" className="text-sm font-medium">
+            Archived accounts
+          </h2>
+          <p className="text-muted-foreground max-w-prose text-xs/relaxed">
+            Unarchiving makes an account available for new transactions again.
+            Its history stays intact.
+          </p>
+        </div>
+        {accounts.length === 0 ? (
+          <Empty className="border py-8">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <Archive aria-hidden="true" />
+              </EmptyMedia>
+              <EmptyTitle>No archived accounts</EmptyTitle>
+              <EmptyDescription>
+                Accounts you archive will appear here when you need them again.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <ul className="divide-y border-y">
+            {accounts.map((account) => (
+              <li
+                key={account.id}
+                className="flex items-center justify-between gap-3 py-3"
+              >
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <p className="text-sm font-medium wrap-anywhere">
+                    {account.name}
+                  </p>
+                  <p className="text-muted-foreground text-xs/relaxed wrap-anywhere">
+                    {account.user.name} ·{' '}
+                    <span className="capitalize">{account.type}</span> ·{' '}
+                    {account.householdCurrency.code}
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  disabled={isInFlight}
+                  aria-label={`Unarchive ${account.name}`}
+                  onClick={() => unarchive(account.id, account.name)}
+                >
+                  <ArchiveRestore data-icon="inline-start" aria-hidden="true" />
+                  {pendingId === account.id ? 'Unarchiving…' : 'Unarchive'}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+      <p
+        role="status"
+        className="text-muted-foreground text-xs/relaxed empty:hidden"
+      >
+        {feedback}
+      </p>
+    </section>
+  )
+}

--- a/web/src/routes/_user/household/$householdId/settings/__generated__/accountsSettingsQuery.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/settings/__generated__/accountsSettingsQuery.graphql.ts
@@ -1,0 +1,180 @@
+/**
+ * @generated SignedSource<<774e2637c9d28c8bc71c52763bb6c3ff>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type accountsSettingsQuery$variables = Record<PropertyKey, never>;
+export type accountsSettingsQuery$data = {
+  readonly household: {
+    readonly id: string;
+  };
+  readonly " $fragmentSpreads": FragmentRefs<"accountSettingsFragment">;
+};
+export type accountsSettingsQuery = {
+  response: accountsSettingsQuery$data;
+  variables: accountsSettingsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Household",
+  "kind": "LinkedField",
+  "name": "household",
+  "plural": false,
+  "selections": [
+    (v0/*: any*/)
+  ],
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "accountsSettingsQuery",
+    "selections": [
+      (v1/*: any*/),
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "accountSettingsFragment"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "accountsSettingsQuery",
+    "selections": [
+      (v1/*: any*/),
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "where",
+            "value": {
+              "archived": true
+            }
+          }
+        ],
+        "concreteType": "AccountConnection",
+        "kind": "LinkedField",
+        "name": "accounts",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AccountEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Account",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v0/*: any*/),
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "type",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "archived",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v0/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "HouseholdCurrency",
+                    "kind": "LinkedField",
+                    "name": "householdCurrency",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "code",
+                        "storageKey": null
+                      },
+                      (v0/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "accounts(where:{\"archived\":true})"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "85222acbf6f8a29b7f8418b0e9f6590d",
+    "id": null,
+    "metadata": {},
+    "name": "accountsSettingsQuery",
+    "operationKind": "query",
+    "text": "query accountsSettingsQuery {\n  household {\n    id\n  }\n  ...accountSettingsFragment\n}\n\nfragment accountSettingsFragment on Query {\n  accounts(where: {archived: true}) {\n    edges {\n      node {\n        id\n        name\n        type\n        archived\n        user {\n          name\n          id\n        }\n        householdCurrency {\n          code\n          id\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "8857808cb637b364f0dff4acc45fdda1";
+
+export default node;

--- a/web/src/routes/_user/household/$householdId/settings/accounts.tsx
+++ b/web/src/routes/_user/household/$householdId/settings/accounts.tsx
@@ -1,0 +1,53 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { graphql } from 'relay-runtime'
+import {
+  fetchQuery,
+  loadQuery,
+  usePreloadedQuery,
+  useSubscribeToInvalidationState,
+} from 'react-relay'
+import { PendingComponent } from '@/components/pending-component'
+import { environment } from '@/environment'
+import type { accountsSettingsQuery } from './__generated__/accountsSettingsQuery.graphql'
+import { AccountSettings } from './-components/account-settings'
+
+const query = graphql`
+  query accountsSettingsQuery {
+    household {
+      id
+    }
+    ...accountSettingsFragment
+  }
+`
+
+export const Route = createFileRoute(
+  '/_user/household/$householdId/settings/accounts',
+)({
+  component: RouteComponent,
+  pendingComponent: PendingComponent,
+  loader: () => {
+    return loadQuery<accountsSettingsQuery>(
+      environment,
+      query,
+      {},
+      { fetchPolicy: 'store-or-network' },
+    )
+  },
+})
+
+function RouteComponent() {
+  const queryRef = Route.useLoaderData()
+
+  const data = usePreloadedQuery<accountsSettingsQuery>(query, queryRef)
+
+  useSubscribeToInvalidationState([data.household.id], () => {
+    fetchQuery(
+      environment,
+      query,
+      {},
+      { fetchPolicy: 'network-only' },
+    ).subscribe({})
+  })
+
+  return <AccountSettings fragmentRef={data} />
+}

--- a/web/src/routes/_user/household/$householdId/settings/route.tsx
+++ b/web/src/routes/_user/household/$householdId/settings/route.tsx
@@ -21,6 +21,15 @@ const SETTINGS_NAV = [
     }),
   },
   {
+    label: 'Accounts',
+    ...linkOptions({
+      from: '/household/$householdId/settings',
+      to: './accounts',
+      search: identity,
+      activeOptions: { exact: true, includeSearch: false },
+    }),
+  },
+  {
     label: 'Members',
     ...linkOptions({
       from: '/household/$householdId/settings',
@@ -75,11 +84,11 @@ function RouteComponent() {
                 key={label}
                 params={params}
                 className={cn(
-                  'text-muted-foreground -ml-px border-l-2 border-transparent py-0.5 pl-2.5 text-xs/relaxed font-medium transition-colors',
+                  'text-muted-foreground hover:bg-muted focus-visible:outline-ring px-2.5 py-1 text-xs/relaxed font-medium transition-colors focus-visible:outline-2',
                   '',
                 )}
                 activeProps={{
-                  className: 'font-semibold border-l-primary',
+                  className: 'bg-muted text-foreground font-semibold',
                 }}
               >
                 {label}


### PR DESCRIPTION
Archived accounts disappear from the account list with no way to restore them. Add Settings → Accounts with an archived-account list and an Unarchive action that makes accounts available for transactions again while preserving their history.

The dedicated GraphQL mutation respects household isolation, and Relay updates the archive list and invalidates household data after restoration. The page includes pending, error, and empty states, responsive account rows, and an archive-dialog hint pointing to the new settings page.

Closes #188

Validation:
- 32 frontend tests passed, including restore success, failure/retry, and empty-state coverage.
- ESLint, TypeScript, formatting, and production frontend build passed.
- `go test ./gql ./ent/rules` and `go build ./...` passed.
- Browser review of the component with sample data at desktop and 375px mobile widths.
