### PR TITLE
Fix frontend CI environment dependency in transaction table tests

### DIFF
--- a/web/src/routes/_user/household/$householdId/transactions/-components/transactions-table.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transactions-table.test.tsx
@@ -18,6 +18,9 @@ const state = vi.hoisted(() => ({
   inView: false,
   navigate: vi.fn(),
 }))
+vi.mock('@/env', () => ({
+  env: { VITE_SERVER_URL: 'https://api.example.test' },
+}))
 vi.mock('react-intersection-observer', () => ({
   useInView: () => ({ ref: () => {}, inView: state.inView }),
 }))


### PR DESCRIPTION
The transaction-table test imports the logo helper, which validates application environment variables during module loading. On CI, `VITE_SERVER_URL` is absent, so the entire suite fails before any tests run.

Mock the environment module in that test with a deterministic endpoint, following the existing Relay transport test pattern. The suite no longer depends on a local `.env` file; production environment validation is unchanged.

Validation: reproduced the original failure with `VITE_SERVER_URL=`; all 45 frontend tests now pass under that same condition. TypeScript, ESLint, and Prettier checks pass.
