### PR TITLE
fix: prevent tracing panic on persisted-query cache misses

### DIFF
--- a/cmd/server/graphql.go
+++ b/cmd/server/graphql.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/handler"
+	gqlgen_opentelemetry "github.com/zhevron/gqlgen-opentelemetry"
+)
+
+func newGraphQLHandler(schema graphql.ExecutableSchema) *handler.Server {
+	server := handler.NewDefaultServer(schema)
+	server.Use(operationTracer{})
+	return server
+}
+
+type operationTracer struct {
+	gqlgen_opentelemetry.Tracer
+}
+
+func (t operationTracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+	// APQ misses and validation errors have a context but no parsed operation.
+	// The upstream tracer dereferences Operation without checking it.
+	if !graphql.HasOperationContext(ctx) || graphql.GetOperationContext(ctx).Operation == nil {
+		return next(ctx)
+	}
+	return t.Tracer.InterceptResponse(ctx, next)
+}

--- a/cmd/server/graphql_test.go
+++ b/cmd/server/graphql_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"beavermoney.app/gql"
+	"github.com/99designs/gqlgen/graphql"
+)
+
+func TestGraphQLPersistedQueryHandshake(t *testing.T) {
+	server := newGraphQLHandler(gql.NewExecutableSchema(gql.Config{Resolvers: &gql.Resolver{}}))
+	query := "query TestQuery { __typename }"
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(query)))
+	payload := map[string]any{
+		"operationName": "TestQuery",
+		"extensions": map[string]any{
+			"persistedQuery": map[string]any{"version": 1, "sha256Hash": hash},
+		},
+	}
+
+	miss := postGraphQL(t, server, payload)
+	if len(miss.Errors) != 1 || miss.Errors[0].Extensions["code"] != "PERSISTED_QUERY_NOT_FOUND" {
+		t.Fatalf("expected APQ cache miss, got %+v", miss)
+	}
+
+	payload["query"] = query
+	registered := postGraphQL(t, server, payload)
+	if len(registered.Errors) != 0 || string(registered.Data) != `{"__typename":"Query"}` {
+		t.Fatalf("expected successful registration, got %+v", registered)
+	}
+
+	delete(payload, "query")
+	hit := postGraphQL(t, server, payload)
+	if len(hit.Errors) != 0 || string(hit.Data) != string(registered.Data) {
+		t.Fatalf("expected cached query execution, got %+v", hit)
+	}
+}
+
+func TestGraphQLInvalidOperationsDoNotPanic(t *testing.T) {
+	server := newGraphQLHandler(gql.NewExecutableSchema(gql.Config{Resolvers: &gql.Resolver{}}))
+	for _, query := range []string{"", "query {", "query { nonexistentField }"} {
+		t.Run(query, func(t *testing.T) {
+			response := postGraphQL(t, server, map[string]any{"query": query})
+			if len(response.Errors) == 0 {
+				t.Fatal("expected a request error")
+			}
+			for _, err := range response.Errors {
+				if strings.Contains(err.Message, "internal system error") {
+					t.Fatalf("request error became a panic: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func postGraphQL(t *testing.T, server http.Handler, payload map[string]any) graphql.Response {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/query", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	var response graphql.Response
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("invalid GraphQL response: %v: %s", err, recorder.Body.String())
+	}
+	return response
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	sentryotel "github.com/getsentry/sentry-go/otel"
-	gqlgen_opentelemetry "github.com/zhevron/gqlgen-opentelemetry"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
@@ -35,7 +34,6 @@ import (
 	"beavermoney.app/internal/seed"
 	"entgo.io/contrib/entgql"
 	entsql "entgo.io/ent/dialect/sql"
-	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/getsentry/sentry-go"
 	sentryhttp "github.com/getsentry/sentry-go/http"
@@ -245,7 +243,7 @@ func main() {
 	r.Use(sentryMiddleware.Handle) // must be after Recoverer
 
 	// Setup GQL
-	gqlHandler := handler.NewDefaultServer(
+	gqlHandler := newGraphQLHandler(
 		gql.NewSchema(
 			logger,
 			entClient,
@@ -256,7 +254,6 @@ func main() {
 			otel.Tracer("beavermoney-server"),
 		),
 	)
-	gqlHandler.Use(gqlgen_opentelemetry.Tracer{})
 	gqlHandler.Use(entgql.Transactioner{TxOpener: entClient})
 
 	r.Group(func(r chi.Router) {


### PR DESCRIPTION
Persisted-query cache misses were crashing the OpenTelemetry response tracer because gqlgen has an operation context but no parsed operation yet. The frontend received `internal system error` instead of `PERSISTED_QUERY_NOT_FOUND`, preventing its full-query retry and breaking page loads after the APQ rollout.

Guard tracing until an operation exists, preserving the original APQ and validation errors while retaining tracing for valid operations. Keep the default server's existing APQ support.

Validation: the new HTTP regression test reproduces the exact production panic with the original tracer and passes with the guard. Tests cover cache miss → full-query registration → hash-only cache hit, plus empty, malformed, and invalid queries. `go test ./cmd/server` passes. Local lint is unavailable because the installed binary was built with Go 1.25; CI uses the configured version.
