### PR TITLE
Standardize category icon strokes and transaction avatar sizes

### DIFF
--- a/web/src/components/category-glyph.test.tsx
+++ b/web/src/components/category-glyph.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act, render, screen } from '@testing-library/react'
 import { expect, it, vi } from 'vitest'
-import { CategoryIcon } from './category-icon'
+import { CategoryGlyph } from './category-glyph'
 
 const { loadIcon } = vi.hoisted(() => ({
   loadIcon: vi.fn(async () => ({
@@ -14,7 +14,7 @@ vi.mock('lucide-react/dynamic', () => ({
 
 it('reserves icon space and immediately renders a cached icon on remount', async () => {
   const first = render(
-    <CategoryIcon name="wallet" fallback={<span>Loading icon</span>} />,
+    <CategoryGlyph name="wallet" fallback={<span>Loading icon</span>} />,
   )
   expect(screen.getByText('Loading icon').parentElement?.className).toContain(
     'size-4 shrink-0',
@@ -25,7 +25,7 @@ it('reserves icon space and immediately renders a cached icon on remount', async
   expect(first.container.querySelector('svg')).not.toBeNull()
   first.unmount()
   const second = render(
-    <CategoryIcon name="wallet" fallback={<span>Loading icon</span>} />,
+    <CategoryGlyph name="wallet" fallback={<span>Loading icon</span>} />,
   )
   expect(second.container.querySelector('svg')).not.toBeNull()
   expect(screen.queryByText('Loading icon')).toBeNull()

--- a/web/src/components/category-glyph.tsx
+++ b/web/src/components/category-glyph.tsx
@@ -1,17 +1,20 @@
 import { useEffect, useSyncExternalStore, type ReactNode } from 'react'
 import { Icon, type IconNode } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { dynamicIconImports, type IconName } from 'lucide-react/dynamic'
 
 const icons = new Map<IconName, IconNode>()
 const pending = new Map<IconName, Promise<void>>()
 const listeners = new Map<IconName, Set<() => void>>()
 
-export function CategoryIcon({
+export function CategoryGlyph({
   name,
   fallback,
+  className,
 }: {
   name: IconName
   fallback: ReactNode
+  className?: string
 }) {
   const iconNode = useSyncExternalStore(
     (listener) => {
@@ -45,10 +48,13 @@ export function CategoryIcon({
 
   return (
     <span
-      className="flex size-4 shrink-0 items-center justify-center"
+      className={cn(
+        'flex size-4 shrink-0 items-center justify-center [&>svg]:size-full',
+        className,
+      )}
       aria-hidden="true"
     >
-      {iconNode ? <Icon iconNode={iconNode} className="size-4" /> : fallback}
+      {iconNode ? <Icon iconNode={iconNode} /> : fallback}
     </span>
   )
 }

--- a/web/src/components/category-icon.tsx
+++ b/web/src/components/category-icon.tsx
@@ -1,0 +1,58 @@
+import {
+  ArrowLeftRightIcon,
+  BanknoteArrowDownIcon,
+  BanknoteArrowUpIcon,
+  TrendingUpIcon,
+  WrenchIcon,
+} from 'lucide-react'
+import { dynamicIconImports, type IconName } from 'lucide-react/dynamic'
+import { CategoryGlyph } from '@/components/category-glyph'
+import { cn } from '@/lib/utils'
+
+export function CategoryIcon({
+  type,
+  icon,
+  size = 'default',
+}: {
+  type: string
+  icon?: string | null
+  size?: 'inline' | 'sm' | 'default'
+}) {
+  const TypeIcon =
+    type === 'income'
+      ? BanknoteArrowUpIcon
+      : type === 'expense'
+        ? BanknoteArrowDownIcon
+        : type === 'investment'
+          ? TrendingUpIcon
+          : type === 'setup'
+            ? WrenchIcon
+            : ArrowLeftRightIcon
+  const fallback = <TypeIcon className="size-4" />
+
+  return (
+    <span
+      className={cn(
+        'text-muted-foreground flex shrink-0 items-center justify-center rounded-full',
+        size !== 'inline' && 'bg-muted',
+        size === 'inline' && 'size-4',
+        size === 'sm' && 'size-6',
+        size === 'default' && 'size-8',
+        type === 'expense' && 'text-destructive',
+        type === 'investment' && 'text-chart-investment',
+        type === 'income' && 'text-chart-net-worth',
+      )}
+      aria-hidden="true"
+    >
+      {icon && Object.hasOwn(dynamicIconImports, icon) ? (
+        <CategoryGlyph
+          name={icon as IconName}
+          fallback={fallback}
+          className="size-4"
+        />
+      ) : (
+        fallback
+      )}
+    </span>
+  )
+}

--- a/web/src/routes/_user/household/$householdId/categories/-components/category-card.tsx
+++ b/web/src/routes/_user/household/$householdId/categories/-components/category-card.tsx
@@ -1,18 +1,9 @@
+import { CategoryIcon } from '@/components/category-icon'
 import { graphql } from 'relay-runtime'
 import { useFragment } from 'react-relay'
 import { Link } from '@tanstack/react-router'
-import {
-  ArrowLeftRightIcon,
-  BanknoteArrowDownIcon,
-  BanknoteArrowUpIcon,
-  TrendingUpIcon,
-  WrenchIcon,
-} from 'lucide-react'
-import { DynamicIcon, type IconName } from 'lucide-react/dynamic'
-import { match } from 'ts-pattern'
 import currency from 'currency.js'
 import { useMemo } from 'react'
-import type { TransactionCategoryType } from './__generated__/categoryCardFragment.graphql'
 import { cn } from '@/lib/utils'
 
 import { useCurrency } from '@/hooks/use-currency'
@@ -104,12 +95,7 @@ export function CategoryCard({
       params={{ categoryId: category.id }}
     >
       <div className="flex items-center gap-2">
-        <div className="size-6 shrink-0 overflow-hidden rounded-full [&>svg]:size-6 [&>svg]:p-1">
-          {getCategoryTypeIcon({
-            type: category.type,
-            icon: category.icon,
-          })}
-        </div>
+        <CategoryIcon type={category.type} icon={category.icon} size="sm" />
         <span className="min-w-0 truncate font-medium">{category.name}</span>
       </div>
       <div className="flex items-baseline gap-2">
@@ -131,67 +117,4 @@ export function CategoryCard({
       </div>
     </Link>
   )
-}
-
-function getCategoryTypeIcon({
-  type,
-  icon,
-}: {
-  type: TransactionCategoryType
-  icon: string | null | undefined
-}) {
-  // If custom icon is provided, use DynamicIcon
-  if (icon) {
-    return match(type)
-      .with('income', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-green-500/90 p-1.5 text-white"
-        />
-      ))
-      .with('expense', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-red-500/90 p-1.5 text-white"
-        />
-      ))
-      .with('transfer', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-orange-500/90 p-1.5 text-white"
-        />
-      ))
-      .with('setup', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-orange-500/90 p-1.5 text-white"
-        />
-      ))
-      .with('investment', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-blue-500/90 p-1.5 text-white"
-        />
-      ))
-      .otherwise(() => null)
-  }
-
-  // Fallback to default icons
-  return match(type)
-    .with('income', () => (
-      <BanknoteArrowUpIcon className="size-10 bg-green-500/90 p-1.5 text-white" />
-    ))
-    .with('expense', () => (
-      <BanknoteArrowDownIcon className="size-10 bg-red-500/90 p-1.5 text-white" />
-    ))
-    .with('transfer', () => (
-      <ArrowLeftRightIcon className="size-10 bg-orange-500/90 p-1.5 text-white" />
-    ))
-    .with('setup', () => (
-      <WrenchIcon className="size-10 bg-orange-500/90 p-1.5 text-white" />
-    ))
-    .with('investment', () => (
-      <TrendingUpIcon className="size-10 bg-blue-500/90 p-1.5 text-white" />
-    ))
-    .otherwise(() => null)
 }

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.tsx
@@ -1,11 +1,5 @@
-import { CategoryIcon } from './category-icon'
+import { CategoryIcon } from '@/components/category-icon'
 import { SelectionRows } from './selection-rows'
-import {
-  ArrowLeftRightIcon,
-  BanknoteArrowDownIcon,
-  BanknoteArrowUpIcon,
-} from 'lucide-react'
-import { iconNames } from 'lucide-react/dynamic'
 import {
   Combobox,
   ComboboxContent,
@@ -71,36 +65,11 @@ export function TransactionCategoryPicker({
                   aria-invalid={invalid}
                   className="sr-only"
                 />
-                {category.icon &&
-                iconNames.some((name) => name === category.icon) ? (
-                  <CategoryIcon
-                    name={category.icon as (typeof iconNames)[number]}
-                    fallback={
-                      category.type === 'expense' ? (
-                        <BanknoteArrowDownIcon className="size-4" />
-                      ) : category.type === 'income' ? (
-                        <BanknoteArrowUpIcon className="size-4" />
-                      ) : (
-                        <ArrowLeftRightIcon className="size-4" />
-                      )
-                    }
-                  />
-                ) : category.type === 'expense' ? (
-                  <BanknoteArrowDownIcon
-                    className="size-4 shrink-0"
-                    aria-hidden="true"
-                  />
-                ) : category.type === 'income' ? (
-                  <BanknoteArrowUpIcon
-                    className="size-4 shrink-0"
-                    aria-hidden="true"
-                  />
-                ) : (
-                  <ArrowLeftRightIcon
-                    className="size-4 shrink-0"
-                    aria-hidden="true"
-                  />
-                )}
+                <CategoryIcon
+                  type={category.type}
+                  icon={category.icon}
+                  size="inline"
+                />
                 <span
                   className="min-w-0 truncate text-xs leading-relaxed"
                   title={category.name}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-entry-card.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-entry-card.tsx
@@ -1,3 +1,4 @@
+import { CategoryIcon } from '@/components/category-icon'
 import { graphql } from 'relay-runtime'
 import { useFragment } from 'react-relay'
 import { useCurrency } from '@/hooks/use-currency'
@@ -11,16 +12,6 @@ import {
 import { cn } from '@/lib/utils'
 import { format } from 'date-fns'
 import { transactionEntryCardFragment$key } from './__generated__/transactionEntryCardFragment.graphql'
-import { match } from 'ts-pattern'
-import { DynamicIcon, IconName } from 'lucide-react/dynamic'
-import {
-  ArrowLeftRightIcon,
-  BanknoteArrowDownIcon,
-  BanknoteArrowUpIcon,
-  TrendingUpIcon,
-  WrenchIcon,
-} from 'lucide-react'
-import { TransactionCategoryType } from '../__generated__/transactionsQuery.graphql'
 import { Badge } from '@/components/ui/badge'
 
 const transactionEntryCardFragment = graphql`
@@ -85,10 +76,10 @@ export function TransactionEntryCard({
       }}
     >
       <ItemMedia variant="image" className="rounded-full">
-        {getCategoryTypeIcon({
-          type: data.transaction.category.type,
-          icon: data.transaction.category.icon,
-        })}
+        <CategoryIcon
+          type={data.transaction.category.type}
+          icon={data.transaction.category.icon}
+        />
       </ItemMedia>
       <ItemContent className="gap-px">
         <ItemTitle className="">
@@ -114,67 +105,4 @@ export function TransactionEntryCard({
       </ItemContent>
     </Item>
   )
-}
-
-function getCategoryTypeIcon({
-  type,
-  icon,
-}: {
-  type: TransactionCategoryType
-  icon: string | null | undefined
-}) {
-  // If custom icon is provided, use DynamicIcon
-  if (icon) {
-    return match(type)
-      .with('income', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-green-500/90 p-1.5 text-white"
-        />
-      ))
-      .with('expense', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-red-500/90 p-1.5 text-white"
-        />
-      ))
-      .with('transfer', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-orange-500/90 p-1.5 text-white"
-        />
-      ))
-      .with('setup', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-orange-500/90 p-1.5 text-white"
-        />
-      ))
-      .with('investment', () => (
-        <DynamicIcon
-          name={icon as unknown as IconName}
-          className="size-10 bg-blue-500/90 p-1.5 text-white"
-        />
-      ))
-      .otherwise(() => null)
-  }
-
-  // Fallback to default icons
-  return match(type)
-    .with('income', () => (
-      <BanknoteArrowUpIcon className="size-10 bg-green-500/90 p-1.5 text-white" />
-    ))
-    .with('expense', () => (
-      <BanknoteArrowDownIcon className="size-10 bg-red-500/90 p-1.5 text-white" />
-    ))
-    .with('transfer', () => (
-      <ArrowLeftRightIcon className="size-10 bg-orange-500/90 p-1.5 text-white" />
-    ))
-    .with('setup', () => (
-      <WrenchIcon className="size-10 bg-orange-500/90 p-1.5 text-white" />
-    ))
-    .with('investment', () => (
-      <TrendingUpIcon className="size-10 bg-blue-500/90 p-1.5 text-white" />
-    ))
-    .otherwise(() => null)
 }

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transactions-table.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transactions-table.tsx
@@ -6,16 +6,10 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   Columns3Icon,
-  ArrowLeftRightIcon,
-  BanknoteArrowDownIcon,
-  BanknoteArrowUpIcon,
-  TrendingUpIcon,
-  WrenchIcon,
   WalletIcon,
   ListFilterIcon,
 } from 'lucide-react'
-import { dynamicIconImports, type IconName } from 'lucide-react/dynamic'
-import { CategoryIcon } from './category-icon'
+import { CategoryIcon } from '@/components/category-icon'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { getLogoDomainURL } from '@/lib/logo'
 import { format, isToday, isYesterday } from 'date-fns'
@@ -196,36 +190,9 @@ export function TransactionsTable({
       header: 'Transaction',
       cell: (transaction) => {
         const { category } = transaction
-        const TypeIcon =
-          category.type === 'income'
-            ? BanknoteArrowUpIcon
-            : category.type === 'expense'
-              ? BanknoteArrowDownIcon
-              : category.type === 'investment'
-                ? TrendingUpIcon
-                : category.type === 'setup'
-                  ? WrenchIcon
-                  : ArrowLeftRightIcon
         return (
           <div className="flex min-w-0 items-center gap-3">
-            <span
-              className={cn(
-                'bg-muted flex size-8 shrink-0 items-center justify-center',
-                category.type === 'expense' && 'text-destructive',
-                category.type === 'investment' && 'text-chart-investment',
-                category.type === 'income' && 'text-chart-net-worth',
-              )}
-              aria-hidden="true"
-            >
-              {category.icon && category.icon in dynamicIconImports ? (
-                <CategoryIcon
-                  name={category.icon as IconName}
-                  fallback={<TypeIcon className="size-4" />}
-                />
-              ) : (
-                <TypeIcon className="size-4" />
-              )}
-            </span>
+            <CategoryIcon type={category.type} icon={category.icon} />
             <div className="flex min-w-0 flex-col gap-0.5">
               <div className="flex items-center gap-2">
                 <Link
@@ -506,15 +473,15 @@ function AccountMovement({
 }) {
   return (
     <div
-      className="flex h-7 items-center gap-2"
+      className="flex h-8 items-center gap-2"
       title={`${account.name}${symbol ? ` · ${symbol}` : ''}`}
     >
-      <Avatar size="sm" className="size-5">
+      <Avatar>
         {account.icon && (
           <AvatarImage src={getLogoDomainURL(account.icon)} alt="" />
         )}
         <AvatarFallback>
-          <WalletIcon className="size-3" aria-hidden="true" />
+          <WalletIcon className="size-4" aria-hidden="true" />
         </AvatarFallback>
       </Avatar>
       <span className="block max-w-52 truncate">


### PR DESCRIPTION
Transaction rows displayed square category icons beside smaller circular account avatars, while other category surfaces used solid colored backgrounds. Both table icons now use 32px circles with 16px glyphs, and category colors are applied to SVG strokes on muted backgrounds.

A shared category icon component applies the same treatment to category cards, account transaction entries, and the mobile category picker. It preserves cached custom-icon loading and uses transaction-type fallbacks for missing or invalid icons. The Sankey already uses stroke coloring.

Validation: all 48 frontend tests passed, plus Prettier on changed files, ESLint, TypeScript, and the production build. Checked shared components in light and dark browser previews. The build reports the existing large-chunk warning; full authenticated-page visual testing was not performed.
