### PR TITLE
dev: support per-worktree local previews

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -8,7 +8,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = []
   bin = "./tmp/main"
-  cmd = "go build -o ./tmp/main ./cmd/server/main.go"
+  cmd = "go build -o ./tmp/main ./cmd/server"
   delay = 1000
   entrypoint = ["./tmp/main"]
   exclude_dir = ["assets", "tmp", "vendor", "testdata", "web", "node_modules"]

--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ dist
 .pnp.*
 
 .env
+.dev/
 tmp/
 
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,9 @@ just compose up                  # Start PostgreSQL + Redis + Frankfurter
 just server                      # Go server with hot-reload (air), port 3000
 just web                         # Vite dev server, port 5173
 just dev                         # Watch: merge-graphql + relay-compiler
+just worktree-dev                # Shared infra + full app on worktree-specific ports
+just worktree-ready              # Wait for this worktree's app to become ready
+just worktree-url                # Print this worktree's frontend URL
 
 # Code generation
 just codegen                     # Ent + gqlgen
@@ -145,6 +148,19 @@ just migrate-hash                # Hash migrations with Atlas
 cd web && pnpm check             # Prettier + ESLint + TSC
 cd web && pnpm test              # Vitest
 ```
+
+## LOCAL PREVIEW
+
+For browser verification from any checkout or Codex worktree:
+
+1. Run `just worktree-dev` in a long-running terminal session.
+2. Wait for the command to print `READY`, or run `just worktree-ready` from another terminal.
+3. Read the exact frontend URL with `just worktree-url` and open it in the browser.
+4. Use the local development login when authentication is required.
+
+Each worktree gets stable, independent frontend and backend ports. PostgreSQL, Redis, and
+Frankfurter are shared through the `beavermoney` Docker Compose project. Do not assume
+ports 3000 or 5173, and do not start a second app process outside `just worktree-dev`.
 
 ## TECH STACK
 

--- a/cmd/server/config/config.go
+++ b/cmd/server/config/config.go
@@ -40,7 +40,7 @@ func Load() (*Config, error) {
 	isProd := os.Getenv("RAILWAY_PROJECT_NAME") != ""
 
 	if !isProd {
-		if err := godotenv.Load(); err != nil {
+		if err := godotenv.Load(); err != nil && !os.IsNotExist(err) {
 			return nil, err
 		}
 	}

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ server:
   air
 
 merge-graphql:
-  watchexec -w ./gql -e graphql --shell=bash '(rm relay.graphql || true) && node ./scripts/merge-graphql.js'
+  watchexec -w ./gql -e graphql --shell=bash 'node ./scripts/merge-graphql.js'
 
 relay-watch:
   watchexec --exts tsx,ts -w web 'just relay'
@@ -23,7 +23,19 @@ relay:
   pnpm relay-compiler
 
 compose *args:
-  docker-compose -f docker-compose.dev.yml {{args}}
+  docker-compose --project-name beavermoney -f docker-compose.dev.yml {{args}}
+
+# Start shared infrastructure plus this worktree's app on dedicated ports.
+worktree-dev:
+  @./scripts/dev-worktree.sh dev
+
+# Print this worktree's frontend URL.
+worktree-url:
+  @./scripts/dev-worktree.sh url
+
+# Wait until this worktree's frontend and backend are accepting requests.
+worktree-ready:
+  @./scripts/dev-worktree.sh ready
 
 migrate-hash:
   atlas migrate hash --dir file://ent/migrate/migrations --dir-format=golang-migrate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "beavermoney",
   "packageManager": "pnpm@10.33.0",
+  "type": "module",
   "devDependencies": {
     "@graphql-tools/load-files": "^7.0.1",
     "@graphql-tools/merge": "^9.2.3",

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+git_common_dir="$(git rev-parse --git-common-dir)"
+primary_root="$(git -C "$git_common_dir/.." rev-parse --show-toplevel)"
+runtime_dir="$repo_root/.dev"
+ports_file="$runtime_dir/ports.env"
+
+mkdir -p "$runtime_dir"
+
+port_is_available() {
+  ! lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+allocate_ports() {
+  if [[ -f "$ports_file" ]]; then
+    # shellcheck disable=SC1090
+    source "$ports_file"
+    if [[ -n "${DEVTOOLS_PORT:-}" ]]; then
+      return
+    fi
+  fi
+
+  local checksum slot attempts
+  checksum="$(printf '%s' "$repo_root" | cksum | awk '{print $1}')"
+  slot=$((checksum % 400))
+  attempts=0
+
+  while (( attempts < 400 )); do
+    API_PORT=$((3100 + slot * 3))
+    WEB_PORT=$((API_PORT + 1))
+    DEVTOOLS_PORT=$((API_PORT + 2))
+    if port_is_available "$API_PORT" && port_is_available "$WEB_PORT" &&
+      port_is_available "$DEVTOOLS_PORT"; then
+      printf 'API_PORT=%s\nWEB_PORT=%s\nDEVTOOLS_PORT=%s\n' \
+        "$API_PORT" "$WEB_PORT" "$DEVTOOLS_PORT" >"$ports_file"
+      return
+    fi
+    slot=$(((slot + 1) % 400))
+    attempts=$((attempts + 1))
+  done
+
+  echo "Could not find an available worktree port pair." >&2
+  exit 1
+}
+
+load_shared_env() {
+  local backend_env frontend_env
+  backend_env="$repo_root/.env"
+  frontend_env="$repo_root/web/.env"
+
+  [[ -f "$backend_env" ]] || backend_env="$primary_root/.env"
+  [[ -f "$frontend_env" ]] || frontend_env="$primary_root/web/.env"
+
+  if [[ ! -f "$backend_env" ]]; then
+    echo "Missing .env in both this worktree and the primary checkout: $primary_root" >&2
+    exit 1
+  fi
+
+  set -a
+  # shellcheck disable=SC1090
+  source "$backend_env"
+  if [[ -f "$frontend_env" ]]; then
+    # shellcheck disable=SC1090
+    source "$frontend_env"
+  fi
+  set +a
+
+  export PORT="$API_PORT"
+  export WEB_URL="http://localhost:$WEB_PORT"
+  export VITE_SERVER_URL="http://localhost:$API_PORT"
+  export VITE_DEVTOOLS_PORT="$DEVTOOLS_PORT"
+}
+
+frontend_url() {
+  printf 'http://localhost:%s\n' "$WEB_PORT"
+}
+
+wait_until_ready() {
+  local attempts=0
+  while (( attempts < 90 )); do
+    if curl --silent --fail --max-time 2 "http://localhost:$API_PORT/health" >/dev/null &&
+      curl --silent --fail --max-time 2 "http://localhost:$WEB_PORT" >/dev/null; then
+      return
+    fi
+    attempts=$((attempts + 1))
+    sleep 1
+  done
+
+  echo "Timed out waiting for the worktree app." >&2
+  exit 1
+}
+
+start_dev() {
+  load_shared_env
+
+  docker-compose --project-name beavermoney -f "$repo_root/docker-compose.dev.yml" up -d
+
+  # A warm pnpm install is cheap and keeps dependencies correct after branch switches.
+  pnpm --dir "$repo_root" install --frozen-lockfile
+  pnpm --dir "$repo_root/web" install --frozen-lockfile
+
+  # Generate once in order before starting the two independent watchers.
+  # This keeps a fresh worktree from racing Relay against a missing schema.
+  (
+    cd "$repo_root"
+    node ./scripts/merge-graphql.js
+  )
+  pnpm --dir "$repo_root/web" exec relay-compiler
+
+  echo "Frontend: http://localhost:$WEB_PORT"
+  echo "Backend:  http://localhost:$API_PORT"
+
+  (
+    cd "$repo_root"
+    air
+  ) &
+  server_pid=$!
+
+  (
+    cd "$repo_root/web"
+    pnpm exec vite dev --host 127.0.0.1 --port "$WEB_PORT" --strictPort
+  ) &
+  web_pid=$!
+
+  (
+    cd "$repo_root"
+    just dev
+  ) &
+  relay_pid=$!
+
+  cleanup() {
+    trap - EXIT INT TERM
+    kill "$server_pid" "$web_pid" "$relay_pid" >/dev/null 2>&1 || true
+    wait "$server_pid" "$web_pid" "$relay_pid" >/dev/null 2>&1 || true
+  }
+  trap cleanup EXIT INT TERM
+
+  wait_until_ready
+  echo "READY"
+
+  while kill -0 "$server_pid" "$web_pid" "$relay_pid" >/dev/null 2>&1; do
+    sleep 1
+  done
+
+  echo "A development process exited unexpectedly." >&2
+  exit 1
+}
+
+allocate_ports
+
+case "${1:-dev}" in
+dev)
+  start_dev
+  ;;
+ready)
+  wait_until_ready
+  echo "READY"
+  ;;
+url)
+  frontend_url
+  ;;
+*)
+  echo "Usage: $0 {dev|ready|url}" >&2
+  exit 2
+  ;;
+esac

--- a/web/src/env.ts
+++ b/web/src/env.ts
@@ -10,6 +10,7 @@ export const env = createEnv({
 
   client: {
     VITE_SERVER_URL: z.string().min(1),
+    VITE_DEVTOOLS_PORT: z.coerce.number().int().positive().default(42069),
     VITE_LOGO_DEV_PUBLISHABLE_KEY: z.string().optional(),
     VITE_SENTRY_DSN: z.string().optional(),
   },

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import { environment } from '@/environment'
 import { TailwindIndicator } from '@/components/tailwind-indicator'
 import { PrivacyModeProvider } from '@/hooks/use-privacy-mode'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { env } from '@/env'
 
 export const Route = createRootRoute({
   shellComponent: RootDocument,
@@ -24,6 +25,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <TooltipProvider>
           {children}
           <TanStackDevtools
+            eventBusConfig={{ port: env.VITE_DEVTOOLS_PORT }}
             config={{
               position: 'bottom-right',
             }}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,7 +11,11 @@ const config = defineConfig({
   },
   plugins: [
     relay,
-    devtools(),
+    devtools({
+      eventBusConfig: {
+        port: Number(process.env.VITE_DEVTOOLS_PORT ?? 42069),
+      },
+    }),
     tailwindcss(),
     tanstackRouter({
       target: 'react',


### PR DESCRIPTION
## Summary

- add a single `just worktree-dev` command with stable per-worktree frontend, backend, and TanStack devtools ports
- reuse shared Docker infrastructure and primary-checkout environment files
- bootstrap dependencies and GraphQL/Relay artifacts before launching watchers
- document the preview workflow for Codex and developers
- build the complete Go server package in Air

## Validation

- `go build ./...`
- `go test ./cmd/server/config ./cmd/server/auth`
- `pnpm --dir web exec tsc --noEmit`
- `just worktree-dev` reaches `READY`; frontend and backend return HTTP 200
- local development login redirects to the assigned worktree frontend