### PR TITLE
Polish transaction selectors and floating actions

### DIFF
--- a/web/src/routes/_user/household/$householdId/accounts/$accountId/route.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/$accountId/route.tsx
@@ -246,10 +246,11 @@ function RouteComponent() {
           <Outlet />
         </div>
 
-        <div className="fixed right-4 bottom-4 lg:absolute">
+        <div className="fixed right-4 bottom-4 z-20 lg:absolute">
           <Button
             nativeButton={true}
             size="icon-lg"
+            className="size-10 [&_svg:not([class*='size-'])]:size-5"
             onClick={() =>
               openLogTransaction(
                 accountData.type === 'investment' ? 'buy' : 'expense',

--- a/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
@@ -222,7 +222,7 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
 
   return (
     <Fragment>
-      <div className="fixed right-4 bottom-4 flex flex-col items-end gap-2 lg:absolute">
+      <div className="fixed right-4 bottom-4 z-20 flex flex-col items-end gap-2 lg:absolute">
         <Button
           variant="outline"
           nativeButton={true}

--- a/web/src/routes/_user/household/$householdId/categories/-components/categories-panel.tsx
+++ b/web/src/routes/_user/household/$householdId/categories/-components/categories-panel.tsx
@@ -160,7 +160,7 @@ export function CategoriesPanel({ fragmentRef }: CategoriesListPageProps) {
 
   return (
     <Fragment>
-      <div className="fixed right-4 bottom-4 lg:absolute">
+      <div className="fixed right-4 bottom-4 z-20 lg:absolute">
         <PlusButton
           to="/household/$householdId/categories/new"
           params={{ householdId }}

--- a/web/src/routes/_user/household/$householdId/investments/-components/investments-panel.tsx
+++ b/web/src/routes/_user/household/$householdId/investments/-components/investments-panel.tsx
@@ -175,7 +175,7 @@ export function InvestmentsPanel({ fragmentRef }: InvestmentsPanelProps) {
 
   return (
     <Fragment>
-      <div className="fixed right-4 bottom-4 flex flex-col items-end gap-2 lg:absolute">
+      <div className="fixed right-4 bottom-4 z-20 flex flex-col items-end gap-2 lg:absolute">
         <Button
           variant="outline"
           size="icon-lg"

--- a/web/src/routes/_user/household/$householdId/subscriptions/-components/subscriptions-panel.tsx
+++ b/web/src/routes/_user/household/$householdId/subscriptions/-components/subscriptions-panel.tsx
@@ -186,7 +186,7 @@ export function SubscriptionsPanel({ fragmentRef }: SubscriptionsPanelProps) {
 
   return (
     <Fragment>
-      <div className="fixed right-4 bottom-4 flex flex-col items-end gap-2 lg:absolute">
+      <div className="fixed right-4 bottom-4 z-20 flex flex-col items-end gap-2 lg:absolute">
         <PlusButton
           to="/household/$householdId/subscriptions/new"
           params={{ householdId }}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.tsx
@@ -179,6 +179,7 @@ export function TransactionAccountPicker({
                           key={account.id}
                           value={account.id}
                           aria-label={account.name}
+                          closeOnClick
                           className="min-h-10 py-1.5"
                         >
                           <AccountDetails

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.tsx
@@ -11,6 +11,17 @@ import { useCurrency } from '@/hooks/use-currency'
 import { getLogoDomainURL } from '@/lib/logo'
 import { cn } from '@/lib/utils'
 import { newestActivityFirst } from '@/lib/sort-by-update-time'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 const balanceFragment = graphql`
   fragment transactionAccountPickerBalanceFragment on Account {
@@ -58,7 +69,6 @@ export function TransactionAccountPicker({
   onValueChange,
   onBlur,
   invalid,
-  children,
   expanded: controlledExpanded,
   onExpand,
   disabled = false,
@@ -119,7 +129,74 @@ export function TransactionAccountPicker({
     groups.find((group) => preferredTypes?.includes(group.type))?.type ??
     groups[0]?.type
 
-  if (!isMobile) return children
+  if (!isMobile) {
+    return (
+      <DropdownMenu
+        onOpenChange={(open) => {
+          if (!open) onBlur()
+        }}
+      >
+        <DropdownMenuTrigger
+          render={
+            <Button
+              id={name}
+              name={name}
+              type="button"
+              variant="outline"
+              disabled={disabled}
+              aria-invalid={invalid}
+              aria-label={`${label}: ${selected?.name ?? (disabled ? 'Select a source account first' : 'Select an account')}`}
+              className="h-12 w-full justify-start gap-2 p-2 text-left font-normal"
+            />
+          }
+        >
+          {selected ? (
+            <AccountDetails account={selected} />
+          ) : (
+            <span className="text-muted-foreground min-w-0 flex-1 truncate text-left">
+              {disabled ? 'Select a source account first' : 'Select an account'}
+            </span>
+          )}
+          <ChevronDownIcon data-icon="inline-end" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="max-h-none overflow-hidden p-0">
+          <ScrollArea className="max-h-80 [&_[data-slot=scroll-area-viewport]]:max-h-80">
+            <div className="p-1">
+              {groups.map((group, index) => (
+                <div key={group.type}>
+                  {index > 0 ? <DropdownMenuSeparator /> : null}
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel>{group.title}</DropdownMenuLabel>
+                    <DropdownMenuRadioGroup
+                      value={value}
+                      onValueChange={(nextValue) => {
+                        if (typeof nextValue === 'string')
+                          onValueChange(nextValue)
+                      }}
+                    >
+                      {group.accounts.map((account) => (
+                        <DropdownMenuRadioItem
+                          key={account.id}
+                          value={account.id}
+                          aria-label={account.name}
+                          className="min-h-10 py-1.5"
+                        >
+                          <AccountDetails
+                            account={account}
+                            selected={value === account.id}
+                          />
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuGroup>
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+  }
 
   if (!expanded || disabled) {
     return (

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.test.tsx
@@ -63,6 +63,7 @@ it('shows the full category display in desktop options and the selected trigger'
   expect(document.querySelector('[data-slot="scroll-area"]')).not.toBeNull()
   fireEvent.click(screen.getByRole('menuitemradio', { name: 'Groceries' }))
 
+  expect(screen.queryByRole('menu')).toBeNull()
   expect(
     screen.getByRole('button', { name: 'Category: Groceries' }),
   ).toBeTruthy()

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.test.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { TransactionCategoryPicker } from './transaction-category-picker'
 
-vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => true }))
+const mobileState = vi.hoisted(() => ({ value: true }))
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => mobileState.value,
+}))
 vi.mock('./selection-rows', () => ({
   SelectionRows: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -33,7 +37,10 @@ function Picker() {
   )
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  mobileState.value = true
+})
 
 it('collapses to the selected category and expands when clicked', () => {
   render(<Picker />)
@@ -44,4 +51,19 @@ it('collapses to the selected category and expands when clicked', () => {
 
   fireEvent.click(summary)
   expect(screen.getByRole('radio', { name: 'Transport' })).not.toBeNull()
+})
+
+it('shows the full category display in desktop options and the selected trigger', () => {
+  mobileState.value = false
+  render(<Picker />)
+
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Category: Select a category' }),
+  )
+  expect(document.querySelector('[data-slot="scroll-area"]')).not.toBeNull()
+  fireEvent.click(screen.getByRole('menuitemradio', { name: 'Groceries' }))
+
+  expect(
+    screen.getByRole('button', { name: 'Category: Groceries' }),
+  ).toBeTruthy()
 })

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.tsx
@@ -1,16 +1,18 @@
 import { CategoryIcon } from '@/components/category-icon'
 import { SelectionRows } from './selection-rows'
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-} from '@/components/ui/combobox'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { ChevronDownIcon } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 type TransactionCategoryPickerProps = {
   categories: ReadonlyArray<{
@@ -112,33 +114,61 @@ export function TransactionCategoryPicker({
   }
 
   return (
-    <Combobox
-      items={categories.map((category) => category.id)}
-      itemToStringLabel={(item) =>
-        categories.find((category) => category.id === item)?.name || ''
-      }
-      value={value}
-      onValueChange={(nextValue) => onValueChange(nextValue || '')}
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (!open) onBlur()
+      }}
     >
-      <ComboboxInput
-        data-1p-ignore
-        id={name}
-        name={name}
-        placeholder="Select a category"
-        onBlur={onBlur}
-        aria-invalid={invalid}
-      />
-      <ComboboxContent>
-        <ComboboxEmpty>No items found.</ComboboxEmpty>
-        <ComboboxList>
-          {(item: string) => (
-            <ComboboxItem key={item} value={item}>
-              {categories.find((category) => category.id === item)?.name || ''}
-            </ComboboxItem>
-          )}
-        </ComboboxList>
-      </ComboboxContent>
-    </Combobox>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            id={name}
+            name={name}
+            type="button"
+            variant="outline"
+            aria-invalid={invalid}
+            aria-label={`Category: ${selected?.name ?? 'Select a category'}`}
+            className="h-auto min-h-9 w-full justify-between px-2 py-1.5 font-normal"
+          />
+        }
+      >
+        {selected ? (
+          <span className="flex min-w-0 flex-1 items-center gap-2">
+            <CategoryDetails category={selected} />
+          </span>
+        ) : (
+          <span className="text-muted-foreground min-w-0 flex-1 truncate text-left">
+            Select a category
+          </span>
+        )}
+        <ChevronDownIcon data-icon="inline-end" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="max-h-none overflow-hidden p-0">
+        <ScrollArea className="max-h-80 [&_[data-slot=scroll-area-viewport]]:max-h-80">
+          <div className="p-1">
+            <DropdownMenuGroup>
+              <DropdownMenuRadioGroup
+                value={value}
+                onValueChange={(nextValue) => {
+                  if (typeof nextValue === 'string') onValueChange(nextValue)
+                }}
+              >
+                {categories.map((category) => (
+                  <DropdownMenuRadioItem
+                    key={category.id}
+                    value={category.id}
+                    aria-label={category.name}
+                    className="min-h-9"
+                  >
+                    <CategoryDetails category={category} />
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuGroup>
+          </div>
+        </ScrollArea>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.tsx
@@ -128,7 +128,7 @@ export function TransactionCategoryPicker({
             variant="outline"
             aria-invalid={invalid}
             aria-label={`Category: ${selected?.name ?? 'Select a category'}`}
-            className="h-auto min-h-9 w-full justify-between px-2 py-1.5 font-normal"
+            className="h-auto min-h-9 w-full justify-between px-2 py-1.5 text-left font-normal"
           />
         }
       >
@@ -158,6 +158,7 @@ export function TransactionCategoryPicker({
                     key={category.id}
                     value={category.id}
                     aria-label={category.name}
+                    closeOnClick
                     className="min-h-9"
                   >
                     <CategoryDetails category={category} />

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.test.tsx
@@ -94,6 +94,7 @@ it('shows investment identity in desktop options and the selected trigger', () =
     screen.getByRole('menuitemradio', { name: 'Index Fund, IDX' }),
   )
 
+  expect(screen.queryByRole('menu')).toBeNull()
   expect(
     screen.getByRole('button', { name: 'Investment: Index Fund, IDX' }),
   ).toBeTruthy()

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.test.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { TransactionInvestmentPicker } from './transaction-investment-picker'
 
-vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => true }))
+const mobileState = vi.hoisted(() => ({ value: true }))
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => mobileState.value,
+}))
 vi.mock('@/lib/logo', () => ({
   getLogoCryptoURL: () => '',
   getLogoTickerURL: () => '',
@@ -58,7 +62,10 @@ function Picker() {
   )
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  mobileState.value = true
+})
 
 it('collapses to the selected investment and expands when clicked', () => {
   render(<Picker />)
@@ -71,4 +78,23 @@ it('collapses to the selected investment and expands when clicked', () => {
 
   fireEvent.click(summary)
   expect(screen.getByRole('radio', { name: /Bitcoin/ })).not.toBeNull()
+})
+
+it('shows investment identity in desktop options and the selected trigger', () => {
+  mobileState.value = false
+  render(<Picker />)
+
+  fireEvent.click(
+    screen.getByRole('button', {
+      name: 'Investment: Select an investment',
+    }),
+  )
+  expect(document.querySelector('[data-slot="scroll-area"]')).not.toBeNull()
+  fireEvent.click(
+    screen.getByRole('menuitemradio', { name: 'Index Fund, IDX' }),
+  )
+
+  expect(
+    screen.getByRole('button', { name: 'Investment: Index Fund, IDX' }),
+  ).toBeTruthy()
 })

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.tsx
@@ -6,6 +6,16 @@ import { useIsMobile } from '@/hooks/use-mobile'
 import { getLogoCryptoURL, getLogoTickerURL } from '@/lib/logo'
 import { cn } from '@/lib/utils'
 import { newestActivityFirst } from '@/lib/sort-by-update-time'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 type Investment = {
   id: string
@@ -39,7 +49,6 @@ export function TransactionInvestmentPicker({
   invalid,
   disabled = false,
   disabledMessage = 'Select an account first',
-  children,
 }: Props) {
   const isMobile = useIsMobile()
   const [editing, setEditing] = useState(false)
@@ -58,7 +67,66 @@ export function TransactionInvestmentPicker({
     wasExpanded.current = expanded
   }, [expanded, isMobile])
 
-  if (!isMobile) return children
+  if (!isMobile) {
+    return (
+      <DropdownMenu
+        onOpenChange={(open) => {
+          if (!open) onBlur()
+        }}
+      >
+        <DropdownMenuTrigger
+          render={
+            <Button
+              id={name}
+              name={name}
+              type="button"
+              variant="outline"
+              disabled={disabled}
+              aria-invalid={invalid}
+              aria-label={`${label}: ${selected ? `${selected.name}, ${selected.symbol}` : disabled ? disabledMessage : 'Select an investment'}`}
+              className="h-auto min-h-10 w-full justify-between px-2 py-1.5 font-normal"
+            />
+          }
+        >
+          {selected ? (
+            <span className="flex min-w-0 flex-1 items-center gap-2">
+              <InvestmentDetails investment={selected} />
+            </span>
+          ) : (
+            <span className="text-muted-foreground min-w-0 flex-1 truncate text-left">
+              {disabled ? disabledMessage : 'Select an investment'}
+            </span>
+          )}
+          <ChevronDownIcon data-icon="inline-end" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="max-h-none overflow-hidden p-0">
+          <ScrollArea className="max-h-80 [&_[data-slot=scroll-area-viewport]]:max-h-80">
+            <div className="p-1">
+              <DropdownMenuGroup>
+                <DropdownMenuRadioGroup
+                  value={value}
+                  onValueChange={(nextValue) => {
+                    if (typeof nextValue === 'string') onValueChange(nextValue)
+                  }}
+                >
+                  {orderedInvestments.map((investment) => (
+                    <DropdownMenuRadioItem
+                      key={investment.id}
+                      value={investment.id}
+                      aria-label={`${investment.name}, ${investment.symbol}`}
+                      className="min-h-10 py-1.5"
+                    >
+                      <InvestmentDetails investment={investment} />
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuGroup>
+            </div>
+          </ScrollArea>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+  }
 
   if (!expanded && selected) {
     return (

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.tsx
@@ -84,7 +84,7 @@ export function TransactionInvestmentPicker({
               disabled={disabled}
               aria-invalid={invalid}
               aria-label={`${label}: ${selected ? `${selected.name}, ${selected.symbol}` : disabled ? disabledMessage : 'Select an investment'}`}
-              className="h-auto min-h-10 w-full justify-between px-2 py-1.5 font-normal"
+              className="h-auto min-h-10 w-full justify-between px-2 py-1.5 text-left font-normal"
             />
           }
         >
@@ -114,6 +114,7 @@ export function TransactionInvestmentPicker({
                       key={investment.id}
                       value={investment.id}
                       aria-label={`${investment.name}, ${investment.symbol}`}
+                      closeOnClick
                       className="min-h-10 py-1.5"
                     >
                       <InvestmentDetails investment={investment} />

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transactions-panel.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transactions-panel.tsx
@@ -89,7 +89,7 @@ export function TransactionsPanel({ fragmentRef }: TransactionsPanelProps) {
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-      <div className="fixed right-4 bottom-4 lg:absolute">
+      <div className="fixed right-4 bottom-4 z-20 lg:absolute">
         <Button
           nativeButton={true}
           size="icon-lg"


### PR DESCRIPTION
## Summary
- keep floating add/refresh actions above scrollable tables and account cards
- bring rich account, category, and investment option displays to desktop dropdowns
- use shadcn ScrollArea scrollbars in every new transaction selector dropdown
- stabilize and left-align the selected account trigger to match mobile
- restore the standard add-button size on account detail pages

## Verification
- `cd web && pnpm check`
- `cd web && pnpm test` (60 tests)
- `cd web && pnpm build`
- live desktop verification of dropdown scrollbars, floating actions, and account detail add button