### PR TITLE
Cycle account totals through household currencies

### DIFF
--- a/web/src/hooks/use-display-currency.tsx
+++ b/web/src/hooks/use-display-currency.tsx
@@ -3,7 +3,10 @@ import { graphql, useFragment } from 'react-relay'
 import { useStore } from '@tanstack/react-store'
 import currency from 'currency.js'
 import type { useDisplayCurrencyFragment$key } from './__generated__/useDisplayCurrencyFragment.graphql'
-import { displayCurrencyIdStore } from './display-currency-store'
+import {
+  displayCurrencyIdStore,
+  setDisplayCurrencyId,
+} from './display-currency-store'
 import { identity } from 'lodash-es'
 import invariant from 'tiny-invariant'
 import { useUserHousehold } from './use-user-household'
@@ -59,18 +62,36 @@ export const useDisplayCurrency = () => {
 
   const { userHousehold } = useUserHousehold()
 
-  const displayCurrencyCode = useMemo(() => {
+  const displayCurrencies = useMemo(() => {
     invariant(data.householdCurrencies, 'householdCurrencies is required')
 
+    return data.householdCurrencies.filter((currency) => currency.important)
+  }, [data.householdCurrencies])
+
+  const displayCurrencyCode = useMemo(() => {
     if (storedId) {
-      const hc = data.householdCurrencies.find(
-        (c) => c.id === storedId && c.important,
-      )
+      const hc = displayCurrencies.find((currency) => currency.id === storedId)
       if (hc) return hc.code
     }
 
     return userHousehold.householdCurrency.code
-  }, [data.householdCurrencies, storedId, userHousehold.householdCurrency.code])
+  }, [displayCurrencies, storedId, userHousehold.householdCurrency.code])
+
+  const nextDisplayCurrency = useMemo(() => {
+    if (displayCurrencies.length < 2) return null
+
+    const currentIndex = displayCurrencies.findIndex(
+      (currency) => currency.code === displayCurrencyCode,
+    )
+    return displayCurrencies[(currentIndex + 1) % displayCurrencies.length]
+  }, [displayCurrencies, displayCurrencyCode])
+
+  const cycleDisplayCurrency = useCallback(() => {
+    if (!nextDisplayCurrency) return false
+
+    setDisplayCurrencyId(nextDisplayCurrency.id)
+    return true
+  }, [nextDisplayCurrency])
 
   const rateMap = useMemo(() => {
     invariant(data.householdRates, 'householdRates is required')
@@ -99,5 +120,10 @@ export const useDisplayCurrency = () => {
     [displayCurrencyCode, rateMap],
   )
 
-  return { displayCurrencyCode, convert }
+  return {
+    displayCurrencyCode,
+    nextDisplayCurrencyCode: nextDisplayCurrency?.code ?? null,
+    cycleDisplayCurrency,
+    convert,
+  }
 }

--- a/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
@@ -32,7 +32,12 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
-import { useNavigate, useParams, useSearch } from '@tanstack/react-router'
+import {
+  useNavigate,
+  useParams,
+  useRouter,
+  useSearch,
+} from '@tanstack/react-router'
 import {
   ACCOUNT_TYPE_LIST,
   ACCOUNT_CATEGORY_LABEL,
@@ -96,8 +101,14 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
   const data = useFragment(AccountsPanelFragment, fragmentRef)
   const environment = useRelayEnvironment()
   const { household: _household } = useHousehold()
-  const { displayCurrencyCode, convert } = useDisplayCurrency()
+  const {
+    displayCurrencyCode,
+    nextDisplayCurrencyCode,
+    cycleDisplayCurrency,
+    convert,
+  } = useDisplayCurrency()
   const navigate = useNavigate()
+  const router = useRouter()
   const { householdId } = useParams({
     from: '/_user/household/$householdId',
   })
@@ -220,6 +231,21 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
     ]
   }, [data.accounts, convert])
 
+  const formattedDisplayValue = formatCurrencyWithPrivacyMode({
+    value: displayOptions[displayIndex].value,
+    currencyCode: displayCurrencyCode,
+    liability: displayIndex === 2,
+  })
+
+  const handleCycleDisplayCurrency = () => {
+    if (!cycleDisplayCurrency()) return
+
+    commitLocalUpdate(environment, (store) => {
+      store.invalidateStore()
+    })
+    router.invalidate()
+  }
+
   return (
     <Fragment>
       <div className="fixed right-4 bottom-4 z-20 flex flex-col items-end gap-2 lg:absolute">
@@ -254,13 +280,21 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
             </button>
           ))}
         </div>
-        <div className="text-3xl font-semibold tracking-tight tabular-nums">
-          {formatCurrencyWithPrivacyMode({
-            value: displayOptions[displayIndex].value,
-            currencyCode: displayCurrencyCode,
-            liability: displayIndex === 2, // Show liability formatting for Total Liabilities
-          })}
-        </div>
+        {nextDisplayCurrencyCode ? (
+          <button
+            type="button"
+            onClick={handleCycleDisplayCurrency}
+            title={`Switch to ${nextDisplayCurrencyCode}`}
+            aria-label={`${displayOptions[displayIndex].label}: ${formattedDisplayValue}. Displayed in ${displayCurrencyCode}. Switch to ${nextDisplayCurrencyCode}.`}
+            className="focus-visible:ring-ring/30 -mx-1 w-fit cursor-pointer px-1 text-left text-3xl font-semibold tracking-tight tabular-nums outline-none focus-visible:ring-2"
+          >
+            {formattedDisplayValue}
+          </button>
+        ) : (
+          <div className="text-3xl font-semibold tracking-tight tabular-nums">
+            {formattedDisplayValue}
+          </div>
+        )}
       </div>
       <div className="py-2"></div>
       <Suspense


### PR DESCRIPTION
## Summary
- make the large Accounts total cycle through important household currencies
- persist the selected display currency and refresh converted account data
- keep single-currency households non-interactive
- preserve keyboard focus and accessible current/next-currency labeling

## Verification
- Prettier
- ESLint
- TypeScript
- Vitest (60 tests)
- Vite production build
- live CAD/USD browser verification