### PR TITLE
Redesign accounts ledger and fix transaction focus

### DIFF
--- a/web/src/routes/_user/household/$householdId/accounts/-components/__generated__/accountLedgerRowFragment.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/__generated__/accountLedgerRowFragment.graphql.ts
@@ -1,0 +1,143 @@
+/**
+ * @generated SignedSource<<627211263c09c49c64a024b47cff2e49>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type AccountType = "investment" | "liability" | "liquidity" | "property" | "receivable" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type accountLedgerRowFragment$data = {
+  readonly balance: string;
+  readonly householdCurrency: {
+    readonly code: string;
+  };
+  readonly icon: string | null | undefined;
+  readonly id: string;
+  readonly latestTransaction: {
+    readonly datetime: any;
+  } | null | undefined;
+  readonly name: string;
+  readonly type: AccountType;
+  readonly user: {
+    readonly name: string;
+  };
+  readonly value: string;
+  readonly " $fragmentType": "accountLedgerRowFragment";
+};
+export type accountLedgerRowFragment$key = {
+  readonly " $data"?: accountLedgerRowFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"accountLedgerRowFragment">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "accountLedgerRowFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "type",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "icon",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "value",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "balance",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Transaction",
+      "kind": "LinkedField",
+      "name": "latestTransaction",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "datetime",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "HouseholdCurrency",
+      "kind": "LinkedField",
+      "name": "householdCurrency",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "code",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "User",
+      "kind": "LinkedField",
+      "name": "user",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/)
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Account",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "d3bc834a464e8c2559c4323d96267731";
+
+export default node;

--- a/web/src/routes/_user/household/$householdId/accounts/-components/__generated__/accountsPanelFragment.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/__generated__/accountsPanelFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<edf4f70f3e058028c0f03887d5dacd75>>
+ * @generated SignedSource<<24c5f84c80c3285fc31d0ca0b04a020d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,10 +22,13 @@ export type accountsPanelFragment$data = {
           readonly code: string;
         };
         readonly id: string;
+        readonly latestTransaction: {
+          readonly datetime: any;
+        } | null | undefined;
         readonly name: string;
         readonly type: AccountType;
         readonly value: string;
-        readonly " $fragmentSpreads": FragmentRefs<"accountCardFragment">;
+        readonly " $fragmentSpreads": FragmentRefs<"accountLedgerRowFragment">;
       } | null | undefined;
     } | null | undefined> | null | undefined;
   };
@@ -172,6 +175,24 @@ return {
                 {
                   "alias": null,
                   "args": null,
+                  "concreteType": "Transaction",
+                  "kind": "LinkedField",
+                  "name": "latestTransaction",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "datetime",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
                   "concreteType": "HouseholdCurrency",
                   "kind": "LinkedField",
                   "name": "householdCurrency",
@@ -190,7 +211,7 @@ return {
                 {
                   "args": null,
                   "kind": "FragmentSpread",
-                  "name": "accountCardFragment"
+                  "name": "accountLedgerRowFragment"
                 },
                 {
                   "alias": null,
@@ -259,6 +280,6 @@ return {
 };
 })();
 
-(node as any).hash = "ed7e99ad4694c35984d8312cded10c49";
+(node as any).hash = "afb11ef57f391bb667d623d16700e6be";
 
 export default node;

--- a/web/src/routes/_user/household/$householdId/accounts/-components/__generated__/accountsPanelRefetch.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/__generated__/accountsPanelRefetch.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2d277186140934dc1a4664d58dcffd93>>
+ * @generated SignedSource<<2accb059d1d1f18ae9b641fa44805d92>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -225,6 +225,25 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "concreteType": "Transaction",
+                            "kind": "LinkedField",
+                            "name": "latestTransaction",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "datetime",
+                                "storageKey": null
+                              },
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "HouseholdCurrency",
                             "kind": "LinkedField",
                             "name": "householdCurrency",
@@ -251,20 +270,8 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "Transaction",
-                            "kind": "LinkedField",
-                            "name": "latestTransaction",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "datetime",
-                                "storageKey": null
-                              },
-                              (v6/*: any*/)
-                            ],
+                            "kind": "ScalarField",
+                            "name": "balance",
                             "storageKey": null
                           },
                           {
@@ -278,13 +285,6 @@ return {
                               (v8/*: any*/),
                               (v6/*: any*/)
                             ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "balance",
                             "storageKey": null
                           },
                           (v5/*: any*/)
@@ -362,16 +362,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9bd0065ff6e47c88d162972312ab0afc",
+    "cacheID": "18e017451f680123b183866aca4b805c",
     "id": null,
     "metadata": {},
     "name": "accountsPanelRefetch",
     "operationKind": "query",
-    "text": "query accountsPanelRefetch(\n  $count: Int = 50\n  $cursor: Cursor\n  $viewUserIds: [ID!]\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...accountsPanelFragment_2mcrba\n    id\n  }\n}\n\nfragment accountCardFragment on Account {\n  id\n  name\n  type\n  icon\n  latestTransaction {\n    datetime\n    id\n  }\n  householdCurrency {\n    code\n    id\n  }\n  user {\n    name\n    id\n  }\n  value\n  balance\n}\n\nfragment accountsPanelFragment_2mcrba on Household {\n  accounts(first: $count, after: $cursor, where: {archived: false, userIDIn: $viewUserIds}) {\n    edges {\n      node {\n        id\n        type\n        category\n        name\n        value\n        householdCurrency {\n          code\n          id\n        }\n        ...accountCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query accountsPanelRefetch(\n  $count: Int = 50\n  $cursor: Cursor\n  $viewUserIds: [ID!]\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...accountsPanelFragment_2mcrba\n    id\n  }\n}\n\nfragment accountLedgerRowFragment on Account {\n  id\n  name\n  type\n  icon\n  value\n  balance\n  latestTransaction {\n    datetime\n    id\n  }\n  householdCurrency {\n    code\n    id\n  }\n  user {\n    name\n    id\n  }\n}\n\nfragment accountsPanelFragment_2mcrba on Household {\n  accounts(first: $count, after: $cursor, where: {archived: false, userIDIn: $viewUserIds}) {\n    edges {\n      node {\n        id\n        type\n        category\n        name\n        value\n        latestTransaction {\n          datetime\n          id\n        }\n        householdCurrency {\n          code\n          id\n        }\n        ...accountLedgerRowFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ed7e99ad4694c35984d8312cded10c49";
+(node as any).hash = "afb11ef57f391bb667d623d16700e6be";
 
 export default node;

--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-row.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-row.tsx
@@ -1,0 +1,209 @@
+import currency from 'currency.js'
+import { graphql } from 'relay-runtime'
+import { useFragment } from 'react-relay'
+import { Link } from '@tanstack/react-router'
+
+import type { accountLedgerRowFragment$key } from './__generated__/accountLedgerRowFragment.graphql'
+import {
+  ACCOUNT_TYPE_ACCENT_CLASSES,
+  formatPercentageWithPrivacyMode,
+} from './account-ledger-utils'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { useCurrency } from '@/hooks/use-currency'
+import { useHousehold } from '@/hooks/use-household'
+import { usePrivacyMode } from '@/hooks/use-privacy-mode'
+import { getLogoDomainURL } from '@/lib/logo'
+import { getRelativeDate } from '@/lib/time'
+import { cn } from '@/lib/utils'
+
+const AccountLedgerRowFragment = graphql`
+  fragment accountLedgerRowFragment on Account {
+    id
+    name
+    type
+    icon
+    value
+    balance
+    latestTransaction {
+      datetime
+    }
+    householdCurrency {
+      code
+    }
+    user {
+      name
+    }
+  }
+`
+
+type AccountLedgerRowProps = {
+  fragmentRef: accountLedgerRowFragment$key
+  displayValue: currency
+  displayCurrencyCode: string
+  share: number
+}
+
+export function AccountLedgerRow({
+  fragmentRef,
+  displayValue,
+  displayCurrencyCode,
+  share,
+}: AccountLedgerRowProps) {
+  const data = useFragment(AccountLedgerRowFragment, fragmentRef)
+  const { household } = useHousehold()
+  const { isPrivacyModeEnabled } = usePrivacyMode()
+  const { formatCurrencyWithPrivacyMode } = useCurrency()
+
+  const balance = currency(data.balance)
+  const value = currency(data.value)
+  const isLiability = data.type === 'liability'
+  const showCash =
+    data.type === 'investment' && value.value !== 0 && balance.value !== 0
+  const cashPercentage = showCash
+    ? Math.abs((balance.value / value.value) * 100)
+    : 0
+  const accentClass = ACCOUNT_TYPE_ACCENT_CLASSES[data.type] ?? 'bg-chart-2'
+  const shareLabel = formatPercentageWithPrivacyMode(
+    share,
+    household.locale,
+    isPrivacyModeEnabled,
+  )
+
+  const activity = data.latestTransaction
+    ? getRelativeDate(new Date(data.latestTransaction.datetime))
+    : 'Never used'
+
+  return (
+    <Link
+      className="group/account-row hover:bg-muted/60 focus-visible:border-ring focus-visible:ring-ring/30 border-t-border grid min-h-16 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 border-t border-transparent px-3 py-2.5 text-xs/relaxed no-underline! transition-colors outline-none focus-visible:ring-2 focus-visible:ring-inset lg:min-h-12 lg:grid-cols-[minmax(13rem,1.45fr)_minmax(5rem,0.45fr)_minmax(7rem,0.65fr)_minmax(8rem,0.7fr)_minmax(8rem,0.75fr)_minmax(8rem,0.8fr)] lg:gap-x-4 lg:py-2"
+      from="/household/$householdId"
+      to="/household/$householdId/accounts/$accountId"
+      search={(prev) => ({ ...prev })}
+      activeOptions={{ exact: true }}
+      activeProps={{ className: 'bg-muted/60' }}
+      params={{ accountId: data.id }}
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        <Avatar size="sm" className="size-7 lg:size-6">
+          <AvatarImage src={getLogoDomainURL(data.icon || '')} alt="" />
+          <AvatarFallback aria-hidden="true">
+            {data.name.slice(0, 2)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span
+            className="truncate text-sm font-medium lg:text-xs/relaxed"
+            title={data.name}
+          >
+            {data.name}
+          </span>
+          {showCash ? (
+            <span className="text-muted-foreground truncate text-[0.6875rem] tabular-nums">
+              Cash{' '}
+              {formatCurrencyWithPrivacyMode({
+                value: balance,
+                currencyCode: data.householdCurrency.code,
+              })}{' '}
+              ·{' '}
+              {formatPercentageWithPrivacyMode(
+                cashPercentage,
+                household.locale,
+                isPrivacyModeEnabled,
+              )}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <span className="text-muted-foreground hidden truncate lg:block">
+        {data.user.name}
+      </span>
+      <span className="text-muted-foreground hidden whitespace-nowrap lg:block">
+        {activity}
+      </span>
+      <span className="hidden text-right tabular-nums lg:block">
+        {formatCurrencyWithPrivacyMode({
+          value,
+          currencyCode: data.householdCurrency.code,
+          liability: isLiability,
+        })}
+      </span>
+      <span className="text-right text-sm font-medium tabular-nums lg:hidden">
+        {formatCurrencyWithPrivacyMode({
+          value,
+          currencyCode: data.householdCurrency.code,
+          liability: isLiability,
+        })}
+      </span>
+      <span className="hidden text-right text-xs/relaxed font-medium tabular-nums lg:block">
+        {formatCurrencyWithPrivacyMode({
+          value: displayValue,
+          currencyCode: displayCurrencyCode,
+          liability: isLiability,
+        })}
+      </span>
+
+      <div className="hidden min-w-0 flex-col gap-1 lg:flex">
+        <span className="text-muted-foreground text-right tabular-nums">
+          {shareLabel}
+        </span>
+        <AllocationRail
+          value={share}
+          accentClass={accentClass}
+          hidden={isPrivacyModeEnabled}
+        />
+      </div>
+
+      <span className="text-muted-foreground truncate lg:hidden">
+        {data.user.name} · {activity}
+      </span>
+      <span className="text-muted-foreground text-right text-[0.6875rem] tabular-nums lg:hidden">
+        {displayCurrencyCode} ·{' '}
+        {formatCurrencyWithPrivacyMode({
+          value: displayValue,
+          currencyCode: displayCurrencyCode,
+          liability: isLiability,
+        })}
+      </span>
+      <div className="col-span-2 flex items-center gap-2 lg:hidden">
+        <AllocationRail
+          value={share}
+          accentClass={accentClass}
+          hidden={isPrivacyModeEnabled}
+          className="flex-1"
+        />
+        <span className="text-muted-foreground w-12 text-right text-[0.625rem] tabular-nums">
+          {shareLabel}
+        </span>
+      </div>
+    </Link>
+  )
+}
+
+type AllocationRailProps = {
+  value: number
+  accentClass: string
+  hidden: boolean
+  className?: string
+}
+
+function AllocationRail({
+  value,
+  accentClass,
+  hidden,
+  className,
+}: AllocationRailProps) {
+  const width = hidden ? 0 : Math.min(100, Math.max(0, value))
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn('bg-border block h-1 overflow-hidden', className)}
+    >
+      <span
+        className={cn('block h-full', accentClass)}
+        style={{ width: `${width}%` }}
+      />
+    </span>
+  )
+}

--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.ts
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.ts
@@ -1,0 +1,23 @@
+export const ACCOUNT_TYPE_ACCENT_CLASSES: Record<string, string> = {
+  liquidity: 'bg-chart-liquidity',
+  investment: 'bg-chart-investment',
+  property: 'bg-chart-property',
+  receivable: 'bg-chart-receivable',
+  liability: 'bg-chart-liability',
+  asset: 'bg-chart-asset',
+}
+
+export function formatPercentageWithPrivacyMode(
+  value: number,
+  locale: string,
+  isPrivacyModeEnabled: boolean,
+) {
+  if (isPrivacyModeEnabled) return '•••'
+  if (!Number.isFinite(value) || value <= 0) return '0%'
+  if (value < 0.01) return '<0.01%'
+
+  return Intl.NumberFormat(locale, {
+    style: 'percent',
+    maximumFractionDigits: value < 1 ? 2 : 1,
+  }).format(value / 100)
+}

--- a/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
@@ -1,28 +1,47 @@
-import { commitLocalUpdate, graphql } from 'relay-runtime'
-import invariant from 'tiny-invariant'
 import { Accordion as AccordionPrimitive } from '@base-ui/react/accordion'
-import { useFragment, useMutation, useRelayEnvironment } from 'react-relay'
-import { capitalize, groupBy, map } from 'lodash-es'
-import { Fragment, Suspense } from 'react'
-import { useMemo, useState } from 'react'
+import {
+  useNavigate,
+  useParams,
+  useRouter,
+  useSearch,
+} from '@tanstack/react-router'
 import currency from 'currency.js'
-import { ChevronDownIcon, ChevronUpIcon, RefreshCwIcon } from 'lucide-react'
+import { capitalize, groupBy } from 'lodash-es'
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  RefreshCwIcon,
+  SearchIcon,
+} from 'lucide-react'
+import { Fragment, Suspense, useMemo, useState } from 'react'
+import { useFragment, useMutation, useRelayEnvironment } from 'react-relay'
+import { commitLocalUpdate, graphql } from 'relay-runtime'
 import { toast } from 'sonner'
+import invariant from 'tiny-invariant'
 import { match } from 'ts-pattern'
-import { AccountCard } from './account-card'
+
+import {
+  ACCOUNT_TYPE_ACCENT_CLASSES,
+  formatPercentageWithPrivacyMode,
+} from './account-ledger-utils'
+import { AccountLedgerRow } from './account-ledger-row'
 import { NetWorthChart } from './net-worth-chart'
-import type { accountsPanelRefreshMutation } from './__generated__/accountsPanelRefreshMutation.graphql'
 import type { accountsPanelFragment$key } from './__generated__/accountsPanelFragment.graphql'
+import type { accountsPanelRefreshMutation } from './__generated__/accountsPanelRefreshMutation.graphql'
+import { PlusButton } from '@/components/plus-button'
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
 } from '@/components/ui/accordion'
-
-import { useCurrency } from '@/hooks/use-currency'
-import { cn } from '@/lib/utils'
-import { useHousehold } from '@/hooks/use-household'
-import { useDisplayCurrency } from '@/hooks/use-display-currency'
+import { Button } from '@/components/ui/button'
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from '@/components/ui/empty'
+import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -31,23 +50,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Button } from '@/components/ui/button'
-import {
-  useNavigate,
-  useParams,
-  useRouter,
-  useSearch,
-} from '@tanstack/react-router'
-import {
-  ACCOUNT_TYPE_LIST,
-  ACCOUNT_CATEGORY_LABEL,
-  ACCOUNT_CATEGORY_APPLICABLE_TYPES,
-} from '@/constant'
-import { PlusButton } from '@/components/plus-button'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Input } from '@/components/ui/input'
-import { SearchIcon } from 'lucide-react'
+import {
+  ACCOUNT_CATEGORY_APPLICABLE_TYPES,
+  ACCOUNT_CATEGORY_LABEL,
+  ACCOUNT_TYPE_LIST,
+} from '@/constant'
+import { useCurrency } from '@/hooks/use-currency'
+import { useDisplayCurrency } from '@/hooks/use-display-currency'
+import { useHousehold } from '@/hooks/use-household'
+import { usePrivacyMode } from '@/hooks/use-privacy-mode'
 import { NodeType, useRegisterConnection } from '@/lib/relay'
+import { cn } from '@/lib/utils'
 
 const AccountsPanelFragment = graphql`
   fragment accountsPanelFragment on Household
@@ -70,10 +84,13 @@ const AccountsPanelFragment = graphql`
           category
           name
           value
+          latestTransaction {
+            datetime
+          }
           householdCurrency {
             code
           }
-          ...accountCardFragment
+          ...accountLedgerRowFragment
         }
       }
     }
@@ -86,27 +103,36 @@ const AccountsPanelRefreshMutation = graphql`
   }
 `
 
+const GROUP_BY_OPTIONS = {
+  type: 'By type',
+  category: 'By category',
+} as const
+
+const SORT_OPTIONS = {
+  value_desc: 'Largest first',
+  updated_desc: 'Recently active',
+  name_asc: 'Name A–Z',
+} as const
+
 type AccountsListPageProps = {
   fragmentRef: accountsPanelFragment$key
 }
 
-const GROUP_BY_OPTIONS = {
-  type: 'By Type',
-  category: 'By Category',
-} as const
-
 type GroupByOption = keyof typeof GROUP_BY_OPTIONS
+type SortOption = keyof typeof SORT_OPTIONS
 
 export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
   const data = useFragment(AccountsPanelFragment, fragmentRef)
   const environment = useRelayEnvironment()
-  const { household: _household } = useHousehold()
+  const { household } = useHousehold()
   const {
     displayCurrencyCode,
     nextDisplayCurrencyCode,
     cycleDisplayCurrency,
     convert,
   } = useDisplayCurrency()
+  const { isPrivacyModeEnabled } = usePrivacyMode()
+  const { formatCurrencyWithPrivacyMode } = useCurrency()
   const navigate = useNavigate()
   const router = useRouter()
   const { householdId } = useParams({
@@ -116,44 +142,56 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
     from: '/_user/household/$householdId/accounts',
   })
   const groupByOption = search.accounts_group_by as GroupByOption
-
-  const handleGroupByChange = (newGroupBy: string | null) => {
-    if (!newGroupBy) return
-    navigate({
-      to: '.',
-      search: (prev) => ({
-        ...prev,
-        accounts_group_by: newGroupBy as GroupByOption,
-      }),
-    })
-  }
+  const sortOption = search.accounts_sort_by as SortOption
 
   useRegisterConnection(data.accounts.__id, NodeType.Account)
 
   const [commitRefreshMutation, isRefreshInFlight] =
     useMutation<accountsPanelRefreshMutation>(AccountsPanelRefreshMutation)
-
   const [displayIndex, setDisplayIndex] = useState(0)
   const [searchFilter, setSearchFilter] = useState('')
 
-  const { formatCurrencyWithPrivacyMode } = useCurrency()
+  const handleGroupByChange = (newGroupBy: string | null) => {
+    if (!newGroupBy) return
+    navigate({
+      to: '.',
+      search: (previous) => ({
+        ...previous,
+        accounts_group_by: newGroupBy as GroupByOption,
+      }),
+    })
+  }
+
+  const handleSortChange = (newSortOption: string | null) => {
+    if (!newSortOption) return
+    navigate({
+      to: '.',
+      search: (previous) => ({
+        ...previous,
+        accounts_sort_by: newSortOption as SortOption,
+      }),
+    })
+  }
 
   const handleRefresh = () => {
     commitRefreshMutation({
       variables: {},
-      onCompleted: (data, errors) => {
-        const result = { status: 'success' as const, data, errors }
+      onCompleted: (refreshData, errors) => {
+        const result = {
+          status: 'success' as const,
+          data: refreshData,
+          errors,
+        }
         match(result)
           .with({ status: 'success', errors: null }, () => {
-            // Invalidate the Relay store to refetch all queries
             commitLocalUpdate(environment, (store) => {
               store.invalidateStore()
             })
             toast.success('Accounts refreshed successfully!')
           })
-          .with({ status: 'success' }, ({ errors }) => {
+          .with({ status: 'success' }, ({ errors: refreshErrors }) => {
             toast.error(
-              `Refresh failed: ${errors?.[0]?.message ?? 'Unknown error'}`,
+              `Refresh failed: ${refreshErrors?.[0]?.message ?? 'Unknown error'}`,
             )
           })
           .exhaustive()
@@ -164,32 +202,106 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
     })
   }
 
+  const accountItems = useMemo(
+    () =>
+      (data.accounts.edges ?? []).map((edge) => {
+        invariant(edge?.node, 'Account node is null')
+        return {
+          node: edge.node,
+          displayValue: convert(
+            edge.node.value,
+            edge.node.householdCurrency.code,
+          ),
+        }
+      }),
+    [data.accounts.edges, convert],
+  )
+
   const groupedAccounts = useMemo(() => {
     if (groupByOption === 'category') {
-      const eligible = (data.accounts.edges ?? []).filter((edge) => {
-        invariant(edge?.node, 'Account node is null')
-        return ACCOUNT_CATEGORY_APPLICABLE_TYPES.has(edge.node.type)
-      })
-      return groupBy(eligible, (edge) => {
-        invariant(edge?.node, 'Account node is null')
-        return edge.node.category ?? 'taxable'
-      })
+      const eligible = accountItems.filter(({ node }) =>
+        ACCOUNT_CATEGORY_APPLICABLE_TYPES.has(node.type),
+      )
+      return groupBy(eligible, ({ node }) => node.category ?? 'taxable')
     }
-    return groupBy(data.accounts.edges, (edge) => {
-      invariant(edge?.node, 'Account node is null')
-      return edge.node.type
-    })
-  }, [data.accounts, groupByOption])
+
+    return groupBy(accountItems, ({ node }) => node.type)
+  }, [accountItems, groupByOption])
 
   const groupKeys = useMemo(() => {
     if (groupByOption === 'category') {
       const keys = Object.keys(groupedAccounts)
-      const categorized = keys.filter((k) => k !== 'taxable').sort()
+      const categorized = keys.filter((key) => key !== 'taxable').sort()
       const taxable = keys.includes('taxable') ? ['taxable'] : []
       return [...categorized, ...taxable]
     }
-    return ACCOUNT_TYPE_LIST.filter((t) => t in groupedAccounts)
+
+    return ACCOUNT_TYPE_LIST.filter((type) => type in groupedAccounts)
   }, [groupedAccounts, groupByOption])
+
+  const visibleGroups = useMemo(() => {
+    const filterLower = searchFilter.trim().toLocaleLowerCase(household.locale)
+
+    return groupKeys
+      .map((key) => {
+        const accounts = groupedAccounts[key].filter(({ node }) => {
+          if (!filterLower) return true
+          return node.name
+            .toLocaleLowerCase(household.locale)
+            .includes(filterLower)
+        })
+
+        accounts.sort((accountA, accountB) => {
+          switch (sortOption) {
+            case 'value_desc':
+              return (
+                Math.abs(accountB.displayValue.value) -
+                Math.abs(accountA.displayValue.value)
+              )
+            case 'updated_desc': {
+              const timeA = accountA.node.latestTransaction
+                ? Date.parse(accountA.node.latestTransaction.datetime)
+                : 0
+              const timeB = accountB.node.latestTransaction
+                ? Date.parse(accountB.node.latestTransaction.datetime)
+                : 0
+              return timeB - timeA
+            }
+            case 'name_asc':
+              return accountA.node.name.localeCompare(
+                accountB.node.name,
+                household.locale,
+              )
+            default:
+              invariant(false, `Unexpected account sort: ${sortOption}`)
+          }
+        })
+
+        return { key, accounts }
+      })
+      .filter(({ accounts }) => accounts.length > 0)
+  }, [groupKeys, groupedAccounts, household.locale, searchFilter, sortOption])
+
+  const displayOptions = useMemo(() => {
+    let assets = currency(0)
+    let liabilities = currency(0)
+
+    for (const account of accountItems) {
+      if (account.node.type === 'liability') {
+        liabilities = liabilities.add(account.displayValue)
+      } else {
+        assets = assets.add(account.displayValue)
+      }
+    }
+
+    return [
+      { label: 'Net Worth', value: assets.add(liabilities) },
+      { label: 'Assets', value: assets },
+      { label: 'Liabilities', value: liabilities },
+    ]
+  }, [accountItems])
+
+  const assetsTotal = Math.abs(displayOptions[1].value.value)
 
   const getGroupLabel = (key: string) => {
     if (groupByOption === 'category') {
@@ -198,38 +310,6 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
     }
     return capitalize(key)
   }
-
-  const displayOptions = useMemo(() => {
-    const assets = (data.accounts.edges ?? [])
-      .filter((edge) => {
-        invariant(edge?.node, 'Account node is null')
-        return edge.node.type !== 'liability'
-      })
-      .map((edge) => {
-        invariant(edge?.node, 'Account node is null')
-        return convert(edge.node.value, edge.node.householdCurrency.code)
-      })
-      .reduce((a, b) => a.add(b), currency(0))
-
-    const liabilities = (data.accounts.edges ?? [])
-      .filter((edge) => {
-        invariant(edge?.node, 'Account node is null')
-        return edge.node.type === 'liability'
-      })
-      .map((edge) => {
-        invariant(edge?.node, 'Account node is null')
-        return convert(edge.node.value, edge.node.householdCurrency.code)
-      })
-      .reduce((a, b) => a.add(b), currency(0))
-
-    const netWorth = assets.add(liabilities) // liabilities are negative
-
-    return [
-      { label: 'Net Worth', value: netWorth },
-      { label: 'Assets', value: assets },
-      { label: 'Liabilities', value: liabilities },
-    ]
-  }, [data.accounts, convert])
 
   const formattedDisplayValue = formatCurrencyWithPrivacyMode({
     value: displayOptions[displayIndex].value,
@@ -253,17 +333,20 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
           variant="outline"
           nativeButton={true}
           size="icon-lg"
-          className="bg-background dark:bg-card size-10 [&_svg:not([class*='size-'])]:size-5"
+          className="bg-background size-10 [&_svg:not([class*='size-'])]:size-5"
           onClick={handleRefresh}
           disabled={isRefreshInFlight}
+          aria-label="Refresh accounts"
         >
           <RefreshCwIcon className={isRefreshInFlight ? 'animate-spin' : ''} />
         </Button>
         <PlusButton
           to="/household/$householdId/accounts/new"
           params={{ householdId }}
+          aria-label="Add account"
         />
       </div>
+
       <div className="flex flex-col gap-1">
         <div className="flex gap-3">
           {displayOptions.map((option, index) => (
@@ -296,163 +379,269 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
           </div>
         )}
       </div>
-      <div className="py-2"></div>
-      <Suspense
-        fallback={
-          <div className="flex w-full flex-col items-stretch gap-0 rounded-md border border-transparent">
-            <div className="flex gap-1 py-px">
-              <Skeleton className="h-5 w-16 rounded-md" />
-              <Skeleton className="h-5 w-12 rounded-md" />
-              <Skeleton className="h-5 w-16 rounded-md" />
-              <Skeleton className="h-5 w-20 rounded-md" />
-              <Skeleton className="h-5 w-18 rounded-md" />
-              <Skeleton className="h-5 w-14 rounded-md" />
-            </div>
-            <div className="py-1"></div>
-            <Skeleton className="h-44 w-full rounded-md" />
-            <div className="flex items-center gap-2 pt-1 pb-2.5">
-              <Skeleton className="h-4 w-28" />
-              <div className="grow"></div>
-              <div className="flex gap-0.5">
-                <Skeleton className="h-5 w-7 rounded-md" />
-                <Skeleton className="h-5 w-7 rounded-md" />
-                <Skeleton className="h-5 w-7 rounded-md" />
-                <Skeleton className="h-5 w-7 rounded-md" />
-                <Skeleton className="h-5 w-7 rounded-md" />
-              </div>
-            </div>
-          </div>
-        }
-      >
+
+      <div className="py-2" />
+      <Suspense fallback={<NetWorthChartSkeleton />}>
         <NetWorthChart />
       </Suspense>
-      <div className="py-2"></div>
-      <div className="flex items-center gap-2">
+      <div className="py-2" />
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <div className="relative flex-1">
           <SearchIcon className="text-muted-foreground/50 absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
           <Input
-            placeholder="Filter accounts..."
+            placeholder="Filter accounts"
             value={searchFilter}
-            onChange={(e) => setSearchFilter(e.target.value)}
-            className="max-w-64 pl-8 text-xs"
+            onChange={(event) => setSearchFilter(event.target.value)}
+            className="w-full pl-8 text-xs sm:max-w-64"
+            aria-label="Filter accounts"
           />
         </div>
-        <Select
-          name="group-accounts"
-          value={groupByOption}
-          onValueChange={handleGroupByChange}
-        >
-          <SelectTrigger className="h-7 w-32">
-            <SelectValue>{GROUP_BY_OPTIONS[groupByOption]}</SelectValue>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              {(
-                Object.entries(GROUP_BY_OPTIONS) as [GroupByOption, string][]
-              ).map(([value, label]) => (
-                <SelectItem key={value} value={value}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="py-2"></div>
-      <Accordion
-        key={groupByOption}
-        multiple
-        className="w-full"
-        defaultValue={[...groupKeys]}
-      >
-        {map(groupKeys, (key) => {
-          const filterLower = searchFilter.toLowerCase()
-          const accounts = groupedAccounts[key]
-            .filter((account) => {
-              if (!filterLower) return true
-              invariant(account?.node, 'Account node is null')
-              return account.node.name.toLowerCase().includes(filterLower)
-            })
-            .sort((a, b) =>
-              (a?.node?.name ?? '').localeCompare(b?.node?.name ?? ''),
-            )
-
-          if (accounts.length === 0) return null
-          const isLiabilityGroup =
-            groupByOption === 'type' && key === 'liability'
-          return (
-            <AccordionItem
-              value={key}
-              key={key}
-              className="data-open:bg-transparent"
+        <div className="grid grid-cols-2 gap-2 sm:flex">
+          <Select
+            name="sort-accounts"
+            value={sortOption}
+            onValueChange={handleSortChange}
+          >
+            <SelectTrigger
+              className="w-full sm:w-36"
+              aria-label="Sort accounts"
             >
-              <AccordionTrigger className="bg-muted/60 flex cursor-pointer items-center justify-normal gap-2 hover:no-underline **:data-[slot=accordion-trigger-icon]:ml-0">
-                <span>{getGroupLabel(key)}</span>
-                <span className="grow"></span>
-                <span className="mr-3 text-sm font-semibold tracking-wide tabular-nums">
-                  {formatCurrencyWithPrivacyMode({
-                    value: accounts
-                      .map((account) => {
-                        invariant(account?.node, 'Account node is null')
-                        return convert(
-                          account.node.value,
-                          account.node.householdCurrency.code,
-                        )
-                      })
-                      .reduce((a, b) => a.add(b), currency(0)),
+              <SelectValue>{SORT_OPTIONS[sortOption]}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {(Object.entries(SORT_OPTIONS) as [SortOption, string][]).map(
+                  ([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ),
+                )}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <Select
+            name="group-accounts"
+            value={groupByOption}
+            onValueChange={handleGroupByChange}
+          >
+            <SelectTrigger
+              className="w-full sm:w-32"
+              aria-label="Group accounts"
+            >
+              <SelectValue>{GROUP_BY_OPTIONS[groupByOption]}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {(
+                  Object.entries(GROUP_BY_OPTIONS) as [GroupByOption, string][]
+                ).map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="py-2" />
+      {visibleGroups.length > 0 ? (
+        <Accordion
+          key={groupByOption}
+          multiple
+          className="ring-foreground/10 overflow-visible border-0 ring-1"
+          defaultValue={visibleGroups.map(({ key }) => key)}
+        >
+          {visibleGroups.map(({ key, accounts }) => {
+            const groupTotal = accounts.reduce(
+              (total, account) => total.add(account.displayValue),
+              currency(0),
+            )
+            const isLiabilityGroup = accounts.every(
+              ({ node }) => node.type === 'liability',
+            )
+            const groupShare = assetsTotal
+              ? (Math.abs(groupTotal.value) / assetsTotal) * 100
+              : 0
+            const groupTypes = new Set(accounts.map(({ node }) => node.type))
+            const groupAccentClass =
+              groupTypes.size === 1
+                ? (ACCOUNT_TYPE_ACCENT_CLASSES[[...groupTypes][0]] ??
+                  'bg-chart-2')
+                : 'bg-chart-2'
+            const groupShareLabel = `${formatPercentageWithPrivacyMode(
+              groupShare,
+              household.locale,
+              isPrivacyModeEnabled,
+            )} of assets`
+
+            return (
+              <AccordionItem
+                value={key}
+                key={key}
+                className="data-open:bg-transparent"
+              >
+                <AccountGroupTrigger
+                  label={getGroupLabel(key)}
+                  total={formatCurrencyWithPrivacyMode({
+                    value: groupTotal,
                     currencyCode: displayCurrencyCode,
                     liability: isLiabilityGroup,
                   })}
-                </span>
-              </AccordionTrigger>
-              <AccordionContent className="-mx-2 pb-0">
-                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
-                  {accounts.map((account) => {
-                    invariant(account?.node, 'Account node is null')
-                    return (
-                      <AccountCard
-                        className="rounded-none"
+                  share={groupShare}
+                  shareLabel={groupShareLabel}
+                  accentClass={groupAccentClass}
+                  hideAllocation={isPrivacyModeEnabled}
+                />
+                <AccordionContent className="-mx-2 pb-0">
+                  <AccountLedgerColumnHeader
+                    displayCurrencyCode={displayCurrencyCode}
+                  />
+                  <div
+                    role="list"
+                    aria-label={`${getGroupLabel(key)} accounts`}
+                  >
+                    {accounts.map((account) => (
+                      <AccountLedgerRow
                         key={account.node.id}
                         fragmentRef={account.node}
+                        displayValue={account.displayValue}
+                        displayCurrencyCode={displayCurrencyCode}
+                        share={
+                          (isLiabilityGroup ? assetsTotal : groupTotal.value)
+                            ? (Math.abs(account.displayValue.value) /
+                                Math.abs(
+                                  isLiabilityGroup
+                                    ? assetsTotal
+                                    : groupTotal.value,
+                                )) *
+                              100
+                            : 0
+                        }
                       />
-                    )
-                  })}
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-          )
-        })}
-      </Accordion>
+                    ))}
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            )
+          })}
+        </Accordion>
+      ) : (
+        <Empty className="border py-10">
+          <EmptyHeader>
+            <EmptyTitle>No accounts found</EmptyTitle>
+            <EmptyDescription>
+              {searchFilter
+                ? `No account names match “${searchFilter}”.`
+                : 'Add an account to start building your balance sheet.'}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      )}
     </Fragment>
   )
 }
 
-function AccordionTrigger({
-  className,
-  children,
-  ...props
-}: AccordionPrimitive.Trigger.Props) {
+function NetWorthChartSkeleton() {
   return (
-    <AccordionPrimitive.Header className="flex">
-      <AccordionPrimitive.Trigger
-        data-slot="accordion-trigger"
-        className={cn(
-          '**:data-[slot=accordion-trigger-icon]:text-muted-foreground group/accordion-trigger flex flex-1 items-start justify-between gap-6 border border-transparent p-2 text-left text-sm/relaxed font-semibold transition-all outline-none hover:underline disabled:pointer-events-none disabled:opacity-50 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4',
-          className,
-        )}
-        {...props}
-      >
-        <ChevronDownIcon
-          strokeWidth={2}
-          data-slot="accordion-trigger-icon"
-          className="pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
-        />
-        <ChevronUpIcon
-          strokeWidth={2}
-          data-slot="accordion-trigger-icon"
-          className="pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
-        />
-        {children}
+    <div className="flex w-full flex-col items-stretch gap-0 rounded-md border border-transparent">
+      <div className="flex gap-1 py-px">
+        <Skeleton className="h-5 w-16 rounded-md" />
+        <Skeleton className="h-5 w-12 rounded-md" />
+        <Skeleton className="h-5 w-16 rounded-md" />
+        <Skeleton className="h-5 w-20 rounded-md" />
+        <Skeleton className="h-5 w-18 rounded-md" />
+        <Skeleton className="h-5 w-14 rounded-md" />
+      </div>
+      <div className="py-1" />
+      <Skeleton className="h-44 w-full rounded-md" />
+      <div className="flex items-center gap-2 pt-1 pb-2.5">
+        <Skeleton className="h-4 w-28" />
+        <div className="grow" />
+        <div className="flex gap-0.5">
+          <Skeleton className="h-5 w-7 rounded-md" />
+          <Skeleton className="h-5 w-7 rounded-md" />
+          <Skeleton className="h-5 w-7 rounded-md" />
+          <Skeleton className="h-5 w-7 rounded-md" />
+          <Skeleton className="h-5 w-7 rounded-md" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function AccountLedgerColumnHeader({
+  displayCurrencyCode,
+}: {
+  displayCurrencyCode: string
+}) {
+  return (
+    <div className="bg-muted/30 text-muted-foreground hidden grid-cols-[minmax(13rem,1.45fr)_minmax(5rem,0.45fr)_minmax(7rem,0.65fr)_minmax(8rem,0.7fr)_minmax(8rem,0.75fr)_minmax(8rem,0.8fr)] gap-x-4 border-t px-3 py-1.5 text-[0.625rem] font-medium tracking-[0.04em] uppercase lg:grid">
+      <span>Account</span>
+      <span>Owner</span>
+      <span>Updated</span>
+      <span className="text-right">Original</span>
+      <span className="text-right">Value ({displayCurrencyCode})</span>
+      <span className="text-right">Share</span>
+    </div>
+  )
+}
+
+type AccountGroupTriggerProps = {
+  label: string
+  total: string
+  share: number
+  shareLabel: string
+  accentClass: string
+  hideAllocation: boolean
+}
+
+function AccountGroupTrigger({
+  label,
+  total,
+  share,
+  shareLabel,
+  accentClass,
+  hideAllocation,
+}: AccountGroupTriggerProps) {
+  const allocationWidth = hideAllocation ? 0 : Math.min(100, Math.max(0, share))
+
+  return (
+    <AccordionPrimitive.Header className="sticky top-0 z-10 flex">
+      <AccordionPrimitive.Trigger className="group/account-group bg-muted hover:bg-input focus-visible:border-ring focus-visible:ring-ring/30 dark:bg-card relative grid min-h-11 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 border border-transparent py-1.5 pr-10 pl-3 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50">
+        <span className="flex min-w-0 items-center gap-2">
+          <span
+            aria-hidden="true"
+            className={cn('size-2 shrink-0', accentClass)}
+          />
+          <span className="truncate text-[0.6875rem] font-semibold tracking-[0.08em] uppercase">
+            {label}
+          </span>
+        </span>
+        <span className="row-span-2 text-right text-base leading-none font-semibold tracking-tight tabular-nums lg:text-sm">
+          {total}
+        </span>
+        <span className="text-muted-foreground absolute top-1/2 right-3 flex size-5 -translate-y-1/2 items-center justify-center">
+          <ChevronDownIcon className="pointer-events-none size-4 group-aria-expanded/account-group:hidden" />
+          <ChevronUpIcon className="pointer-events-none hidden size-4 group-aria-expanded/account-group:block" />
+        </span>
+        <span className="col-span-2 col-start-1 flex min-w-0 items-center gap-2">
+          <span
+            aria-hidden="true"
+            className="bg-border block h-1 min-w-0 flex-1 overflow-hidden"
+          >
+            <span
+              className={cn('block h-full', accentClass)}
+              style={{ width: `${allocationWidth}%` }}
+            />
+          </span>
+          <span className="text-muted-foreground shrink-0 text-[0.625rem] tabular-nums">
+            {shareLabel}
+          </span>
+        </span>
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   )

--- a/web/src/routes/_user/household/$householdId/accounts/__generated__/accountsQuery.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/accounts/__generated__/accountsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0c10fb7cc4930de1a5e04177e33da356>>
+ * @generated SignedSource<<7e3e59ab2e1489319fae036671156a16>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -165,6 +165,25 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "concreteType": "Transaction",
+                        "kind": "LinkedField",
+                        "name": "latestTransaction",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "datetime",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "HouseholdCurrency",
                         "kind": "LinkedField",
                         "name": "householdCurrency",
@@ -191,20 +210,8 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "Transaction",
-                        "kind": "LinkedField",
-                        "name": "latestTransaction",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "datetime",
-                            "storageKey": null
-                          },
-                          (v2/*: any*/)
-                        ],
+                        "kind": "ScalarField",
+                        "name": "balance",
                         "storageKey": null
                       },
                       {
@@ -218,13 +225,6 @@ return {
                           (v3/*: any*/),
                           (v2/*: any*/)
                         ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "balance",
                         "storageKey": null
                       },
                       {
@@ -305,12 +305,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c603bd87529e014917b3c07dd13f4bd7",
+    "cacheID": "545e28ef6e4974fd72afee65c687ef94",
     "id": null,
     "metadata": {},
     "name": "accountsQuery",
     "operationKind": "query",
-    "text": "query accountsQuery(\n  $viewUserIds: [ID!]\n) {\n  household {\n    ...accountsPanelFragment_3rIbPZ\n    id\n  }\n}\n\nfragment accountCardFragment on Account {\n  id\n  name\n  type\n  icon\n  latestTransaction {\n    datetime\n    id\n  }\n  householdCurrency {\n    code\n    id\n  }\n  user {\n    name\n    id\n  }\n  value\n  balance\n}\n\nfragment accountsPanelFragment_3rIbPZ on Household {\n  accounts(first: 50, where: {archived: false, userIDIn: $viewUserIds}) {\n    edges {\n      node {\n        id\n        type\n        category\n        name\n        value\n        householdCurrency {\n          code\n          id\n        }\n        ...accountCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query accountsQuery(\n  $viewUserIds: [ID!]\n) {\n  household {\n    ...accountsPanelFragment_3rIbPZ\n    id\n  }\n}\n\nfragment accountLedgerRowFragment on Account {\n  id\n  name\n  type\n  icon\n  value\n  balance\n  latestTransaction {\n    datetime\n    id\n  }\n  householdCurrency {\n    code\n    id\n  }\n  user {\n    name\n    id\n  }\n}\n\nfragment accountsPanelFragment_3rIbPZ on Household {\n  accounts(first: 50, where: {archived: false, userIDIn: $viewUserIds}) {\n    edges {\n      node {\n        id\n        type\n        category\n        name\n        value\n        latestTransaction {\n          datetime\n          id\n        }\n        householdCurrency {\n          code\n          id\n        }\n        ...accountLedgerRowFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/web/src/routes/_user/household/$householdId/accounts/route.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/route.tsx
@@ -1,16 +1,32 @@
-import { Outlet, createFileRoute } from '@tanstack/react-router'
+import {
+  Outlet,
+  createFileRoute,
+  stripSearchParams,
+} from '@tanstack/react-router'
 import { z } from 'zod'
 
 import { GenericError } from '@/components/generic-error'
 
 const SearchSchema = z.object({
   accounts_group_by: z.enum(['type', 'category']).optional().default('type'),
+  accounts_sort_by: z
+    .enum(['value_desc', 'updated_desc', 'name_asc'])
+    .optional()
+    .default('value_desc'),
 })
+
+const defaultValues = {
+  accounts_group_by: 'type' as const,
+  accounts_sort_by: 'value_desc' as const,
+}
 
 export const Route = createFileRoute('/_user/household/$householdId/accounts')({
   component: RouteComponent,
   validateSearch: SearchSchema,
   errorComponent: GenericError,
+  search: {
+    middlewares: [stripSearchParams(defaultValues)],
+  },
 })
 
 function RouteComponent() {

--- a/web/src/routes/_user/household/$householdId/transactions/-components/log-transaction.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/log-transaction.tsx
@@ -12,6 +12,8 @@ import { logTransactionFragment$key } from './__generated__/logTransactionFragme
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useHotkey } from '@tanstack/react-hotkeys'
 import invariant from 'tiny-invariant'
+
+import { focusInitialTransactionControl } from './transaction-focus'
 import { useLogTransaction } from '@/hooks/use-log-transaction'
 import type { LogTransactionType } from '@/hooks/log-transaction-store'
 import { cn } from '@/lib/utils'
@@ -95,11 +97,9 @@ export function LogTransaction({ fragmentRef }: NewTransactionProps) {
 
   useEffect(() => {
     const frame = requestAnimationFrame(() => {
-      const firstInput = panelRef.current?.querySelector<HTMLElement>(
-        'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled]), [contenteditable="true"]',
-      )
-
-      firstInput?.focus()
+      if (panelRef.current) {
+        focusInitialTransactionControl(panelRef.current)
+      }
     })
 
     return () => cancelAnimationFrame(frame)

--- a/web/src/routes/_user/household/$householdId/transactions/-components/new-buy.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/new-buy.tsx
@@ -290,7 +290,10 @@ export function NewBuy({ fragmentRef }: NewBuyProps) {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
-                  <Field data-invalid={isInvalid}>
+                  <Field
+                    data-invalid={isInvalid}
+                    data-transaction-initial-focus
+                  >
                     <FieldLabel htmlFor={field.name}>Account</FieldLabel>
                     <TransactionAccountPicker
                       accounts={investmentAccounts}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/new-expense.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/new-expense.tsx
@@ -252,7 +252,10 @@ export function NewExpense({ fragmentRef }: NewExpenseProps) {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
-                  <Field data-invalid={isInvalid}>
+                  <Field
+                    data-invalid={isInvalid}
+                    data-transaction-initial-focus
+                  >
                     <FieldLabel htmlFor={field.name}>Category</FieldLabel>
                     <TransactionCategoryPicker
                       categories={expenseCategories}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/new-income.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/new-income.tsx
@@ -241,7 +241,10 @@ export function NewIncome({ fragmentRef }: NewIncomeProps) {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
-                  <Field data-invalid={isInvalid}>
+                  <Field
+                    data-invalid={isInvalid}
+                    data-transaction-initial-focus
+                  >
                     <FieldLabel htmlFor={field.name}>Category</FieldLabel>
                     <TransactionCategoryPicker
                       categories={incomeCategories}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/new-move.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/new-move.tsx
@@ -288,7 +288,10 @@ export function NewMove({ fragmentRef }: NewMoveProps) {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
-                  <Field data-invalid={isInvalid}>
+                  <Field
+                    data-invalid={isInvalid}
+                    data-transaction-initial-focus
+                  >
                     <FieldLabel htmlFor={field.name}>
                       From Investment
                     </FieldLabel>

--- a/web/src/routes/_user/household/$householdId/transactions/-components/new-sell.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/new-sell.tsx
@@ -283,7 +283,10 @@ export function NewSell({ fragmentRef }: NewSellProps) {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
-                  <Field data-invalid={isInvalid}>
+                  <Field
+                    data-invalid={isInvalid}
+                    data-transaction-initial-focus
+                  >
                     <FieldLabel htmlFor={field.name}>Account</FieldLabel>
                     <TransactionAccountPicker
                       accounts={investmentAccounts}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/new-transfer.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/new-transfer.tsx
@@ -283,7 +283,10 @@ export function NewTransfer({ fragmentRef }: NewTransferProps) {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
-                  <Field data-invalid={isInvalid}>
+                  <Field
+                    data-invalid={isInvalid}
+                    data-transaction-initial-focus
+                  >
                     <FieldLabel htmlFor={field.name}>Category</FieldLabel>
                     <TransactionCategoryPicker
                       categories={transferCategories}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-focus.test.ts
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-focus.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { afterEach, expect, it } from 'vitest'
+
+import { focusInitialTransactionControl } from './transaction-focus'
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+it('focuses the first control in the marked transaction field', () => {
+  const container = document.createElement('div')
+  container.innerHTML = `
+    <form>
+      <div data-transaction-initial-focus>
+        <input name="categoryId" />
+      </div>
+      <input name="amount" />
+    </form>
+  `
+  document.body.append(container)
+
+  const focusedControl = focusInitialTransactionControl(container)
+
+  expect(focusedControl).toBe(
+    container.querySelector<HTMLInputElement>('[name="categoryId"]'),
+  )
+  expect(document.activeElement).toBe(focusedControl)
+})
+
+it('falls back to the first enabled form control', () => {
+  const container = document.createElement('div')
+  container.innerHTML = `
+    <form>
+      <input type="hidden" name="ignored" />
+      <input name="description" />
+      <input name="amount" />
+    </form>
+  `
+  document.body.append(container)
+
+  const focusedControl = focusInitialTransactionControl(container)
+
+  expect(focusedControl).toBe(
+    container.querySelector<HTMLInputElement>('[name="description"]'),
+  )
+  expect(document.activeElement).toBe(focusedControl)
+})

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-focus.ts
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-focus.ts
@@ -1,0 +1,17 @@
+const FOCUSABLE_CONTROL_SELECTOR =
+  'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled]), button:not([disabled]), [contenteditable="true"]'
+
+export function focusInitialTransactionControl(container: HTMLElement) {
+  const initialFocusRegion = container.querySelector<HTMLElement>(
+    '[data-transaction-initial-focus]',
+  )
+  const form = container.querySelector<HTMLFormElement>('form')
+  const firstControl =
+    initialFocusRegion?.querySelector<HTMLElement>(
+      FOCUSABLE_CONTROL_SELECTOR,
+    ) ?? form?.querySelector<HTMLElement>(FOCUSABLE_CONTROL_SELECTOR)
+
+  firstControl?.focus({ preventScroll: true })
+
+  return firstControl ?? null
+}


### PR DESCRIPTION
## Summary

- redesign the accounts view as a responsive, sortable ledger with clearer hierarchy and compact account-type summaries
- show original-currency values consistently, prioritize them on mobile, calculate debt against assets, and preserve display-currency cycling
- improve light/dark theme rails and responsive accordion behavior
- focus the category control first for every log-transaction type, with focused unit coverage

## Verification

- pnpm check
- pnpm test (62 tests)
- pnpm build
- live desktop and mobile QA in light and dark modes