### PR TITLE
Constrain transactions page width

### DIFF
--- a/web/src/routes/_user/household/$householdId/transactions/route.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/route.tsx
@@ -28,7 +28,7 @@ export const Route = createFileRoute(
 function RouteComponent() {
   return (
     <div className="h-[calc(100dvh-2.5rem)] min-h-0 min-w-0 overflow-hidden">
-      <div className="mx-auto flex h-full min-h-0 min-w-0 flex-col overflow-hidden p-4">
+      <div className="mx-auto flex h-full min-h-0 w-full max-w-5xl min-w-0 flex-col overflow-hidden p-4">
         <Outlet />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- constrain the transactions page to the same centered max width as Accounts and Investments
- preserve its existing full-height scrolling behavior and responsive page gutters

## Verification

- pnpm check
- pnpm test --run (62 tests)
- live responsive preview