### PR TITLE
Polish transaction dialog and account interactions

### DIFF
--- a/web/src/components/responsive-selection-picker.tsx
+++ b/web/src/components/responsive-selection-picker.tsx
@@ -1,0 +1,187 @@
+import { ChevronDownIcon } from 'lucide-react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+
+import { SelectionRows } from '@/components/selection-rows'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { useIsMobile } from '@/hooks/use-mobile'
+
+type ResponsiveSelectionPickerProps<T> = {
+  items: ReadonlyArray<T>
+  name: string
+  value: string
+  label: string
+  placeholder: string
+  emptyMessage: string
+  getValue: (item: T) => string
+  getLabel: (item: T) => string
+  renderItem: (item: T) => ReactNode
+  onValueChange: (value: string) => void
+  onBlur: () => void
+  invalid: boolean
+}
+
+export function ResponsiveSelectionPicker<T>({
+  items,
+  name,
+  value,
+  label,
+  placeholder,
+  emptyMessage,
+  getValue,
+  getLabel,
+  renderItem,
+  onValueChange,
+  onBlur,
+  invalid,
+}: ResponsiveSelectionPickerProps<T>) {
+  const isMobile = useIsMobile()
+  const [editing, setEditing] = useState(false)
+  const selected = items.find((item) => getValue(item) === value)
+  const expanded = !selected || editing
+  const summaryRef = useRef<HTMLButtonElement>(null)
+  const wasExpanded = useRef(expanded)
+
+  useEffect(() => {
+    if (isMobile && wasExpanded.current && !expanded) {
+      summaryRef.current?.focus({ preventScroll: true })
+    }
+    wasExpanded.current = expanded
+  }, [expanded, isMobile])
+
+  if (isMobile) {
+    if (!expanded && selected) {
+      return (
+        <button
+          ref={summaryRef}
+          type="button"
+          id={name}
+          aria-expanded={false}
+          aria-label={`${label}: ${getLabel(selected)}`}
+          onClick={() => setEditing(true)}
+          className="border-input bg-background focus-visible:outline-ring flex min-h-9 w-full items-center gap-2 border px-2 py-1.5 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          <span className="flex min-w-0 flex-1 items-center gap-2">
+            {renderItem(selected)}
+          </span>
+          <ChevronDownIcon className="size-4 shrink-0" aria-hidden="true" />
+        </button>
+      )
+    }
+
+    return (
+      <fieldset
+        id={name}
+        aria-invalid={invalid}
+        className="m-0 min-w-0 border-0 p-0"
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) onBlur()
+        }}
+      >
+        <legend className="sr-only">{label}</legend>
+        {items.length === 0 ? (
+          <p className="text-muted-foreground w-full text-xs">{emptyMessage}</p>
+        ) : (
+          <SelectionRows label={label}>
+            {items.map((item) => {
+              const itemValue = getValue(item)
+              return (
+                <label
+                  key={itemValue}
+                  className="border-input bg-background has-checked:border-primary has-focus-visible:outline-ring flex min-h-9 max-w-64 min-w-0 cursor-pointer items-center gap-2 border px-2 py-1.5 has-focus-visible:outline-2 has-focus-visible:-outline-offset-2"
+                >
+                  <input
+                    type="radio"
+                    name={name}
+                    value={itemValue}
+                    checked={value === itemValue}
+                    onChange={() => {
+                      onValueChange(itemValue)
+                      setEditing(false)
+                    }}
+                    onClick={() => {
+                      if (value === itemValue) setEditing(false)
+                    }}
+                    aria-invalid={invalid}
+                    className="sr-only"
+                  />
+                  {renderItem(item)}
+                </label>
+              )
+            })}
+          </SelectionRows>
+        )}
+      </fieldset>
+    )
+  }
+
+  return (
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (!open) onBlur()
+      }}
+    >
+      <DropdownMenuTrigger
+        render={
+          <Button
+            id={name}
+            name={name}
+            type="button"
+            variant="outline"
+            aria-invalid={invalid}
+            aria-label={`${label}: ${selected ? getLabel(selected) : placeholder}`}
+            className="h-auto min-h-9 w-full justify-between px-2 py-1.5 text-left font-normal"
+          />
+        }
+      >
+        {selected ? (
+          <span className="flex min-w-0 flex-1 items-center gap-2">
+            {renderItem(selected)}
+          </span>
+        ) : (
+          <span className="text-muted-foreground min-w-0 flex-1 truncate text-left">
+            {placeholder}
+          </span>
+        )}
+        <ChevronDownIcon data-icon="inline-end" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="max-h-none overflow-hidden p-0">
+        <ScrollArea className="max-h-80 [&_[data-slot=scroll-area-viewport]]:max-h-80">
+          <div className="p-1">
+            <DropdownMenuGroup>
+              <DropdownMenuRadioGroup
+                value={value}
+                onValueChange={(nextValue) => {
+                  if (typeof nextValue === 'string') onValueChange(nextValue)
+                }}
+              >
+                {items.map((item) => {
+                  const itemValue = getValue(item)
+                  return (
+                    <DropdownMenuRadioItem
+                      key={itemValue}
+                      value={itemValue}
+                      aria-label={getLabel(item)}
+                      closeOnClick
+                      className="min-h-9"
+                    >
+                      {renderItem(item)}
+                    </DropdownMenuRadioItem>
+                  )
+                })}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuGroup>
+          </div>
+        </ScrollArea>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/src/components/selection-rows.tsx
+++ b/web/src/components/selection-rows.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   type ReactNode,
 } from 'react'
+
 import { ScrollArea } from '@/components/ui/scroll-area'
 
 /** Balance all cards into viewport-width rows without remounting on selection. */
@@ -36,7 +37,6 @@ export function SelectionRows({
       if (!width) return
       if (width !== previousWidth)
         root.style.setProperty('--selection-width', `${width}px`)
-      // Read geometry once, then apply layout writes together.
       const sizes = elements.map((element, index) => {
         const bounds = element.getBoundingClientRect()
         return { index, width: bounds.width, height: bounds.height }

--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-category-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-category-picker.tsx
@@ -1,0 +1,47 @@
+import { ResponsiveSelectionPicker } from '@/components/responsive-selection-picker'
+import { ACCOUNT_CATEGORY_OPTIONS } from '@/constant'
+
+const NONE_VALUE = '__none__'
+const categoryOptions = [
+  { value: NONE_VALUE, label: 'None (Taxable)' },
+  ...ACCOUNT_CATEGORY_OPTIONS,
+]
+
+type AccountCategoryPickerProps = {
+  name: string
+  value: string
+  onValueChange: (value: string) => void
+  onBlur: () => void
+  invalid: boolean
+}
+
+export function AccountCategoryPicker({
+  name,
+  value,
+  onValueChange,
+  onBlur,
+  invalid,
+}: AccountCategoryPickerProps) {
+  return (
+    <ResponsiveSelectionPicker
+      items={categoryOptions}
+      name={name}
+      value={value || NONE_VALUE}
+      label="Account category"
+      placeholder="None (Taxable)"
+      emptyMessage="No account categories available."
+      getValue={(option) => option.value}
+      getLabel={(option) => option.label}
+      renderItem={(option) => (
+        <span className="min-w-0 flex-1 truncate text-xs leading-relaxed">
+          {option.label}
+        </span>
+      )}
+      onValueChange={(nextValue) =>
+        onValueChange(nextValue === NONE_VALUE ? '' : nextValue)
+      }
+      onBlur={onBlur}
+      invalid={invalid}
+    />
+  )
+}

--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.test.ts
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateAllocationPercentage } from './account-ledger-utils'
+
+describe('calculateAllocationPercentage', () => {
+  it('calculates a liability share against the total liability magnitude', () => {
+    expect(calculateAllocationPercentage(-250, -1000)).toBe(25)
+  })
+
+  it('handles mixed signs and empty totals safely', () => {
+    expect(calculateAllocationPercentage(-250, 1000)).toBe(25)
+    expect(calculateAllocationPercentage(250, 0)).toBe(0)
+  })
+})

--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.ts
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.ts
@@ -21,3 +21,9 @@ export function formatPercentageWithPrivacyMode(
     maximumFractionDigits: value < 1 ? 2 : 1,
   }).format(value / 100)
 }
+
+export function calculateAllocationPercentage(value: number, total: number) {
+  if (!Number.isFinite(value) || !Number.isFinite(total) || total === 0)
+    return 0
+  return (Math.abs(value) / Math.abs(total)) * 100
+}

--- a/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
@@ -22,6 +22,7 @@ import { match } from 'ts-pattern'
 
 import {
   ACCOUNT_TYPE_ACCENT_CLASSES,
+  calculateAllocationPercentage,
   formatPercentageWithPrivacyMode,
 } from './account-ledger-utils'
 import { AccountLedgerRow } from './account-ledger-row'
@@ -302,6 +303,7 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
   }, [accountItems])
 
   const assetsTotal = Math.abs(displayOptions[1].value.value)
+  const liabilitiesTotal = Math.abs(displayOptions[2].value.value)
 
   const getGroupLabel = (key: string) => {
     if (groupByOption === 'category') {
@@ -463,9 +465,14 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
             const isLiabilityGroup = accounts.every(
               ({ node }) => node.type === 'liability',
             )
-            const groupShare = assetsTotal
-              ? (Math.abs(groupTotal.value) / assetsTotal) * 100
-              : 0
+            const allocationTotal = isLiabilityGroup
+              ? liabilitiesTotal
+              : assetsTotal
+            const allocationBasis = isLiabilityGroup ? 'liabilities' : 'assets'
+            const groupShare = calculateAllocationPercentage(
+              groupTotal.value,
+              allocationTotal,
+            )
             const groupTypes = new Set(accounts.map(({ node }) => node.type))
             const groupAccentClass =
               groupTypes.size === 1
@@ -476,7 +483,7 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
               groupShare,
               household.locale,
               isPrivacyModeEnabled,
-            )} of assets`
+            )} of ${allocationBasis}`
 
             return (
               <AccordionItem
@@ -510,17 +517,10 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
                         fragmentRef={account.node}
                         displayValue={account.displayValue}
                         displayCurrencyCode={displayCurrencyCode}
-                        share={
-                          (isLiabilityGroup ? assetsTotal : groupTotal.value)
-                            ? (Math.abs(account.displayValue.value) /
-                                Math.abs(
-                                  isLiabilityGroup
-                                    ? assetsTotal
-                                    : groupTotal.value,
-                                )) *
-                              100
-                            : 0
-                        }
+                        share={calculateAllocationPercentage(
+                          account.displayValue.value,
+                          groupTotal.value,
+                        )}
                       />
                     ))}
                   </div>
@@ -611,7 +611,7 @@ function AccountGroupTrigger({
 
   return (
     <AccordionPrimitive.Header className="sticky top-0 z-10 flex">
-      <AccordionPrimitive.Trigger className="group/account-group bg-muted hover:bg-input focus-visible:border-ring focus-visible:ring-ring/30 dark:bg-card relative grid min-h-11 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 border border-transparent py-1.5 pr-10 pl-3 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50">
+      <AccordionPrimitive.Trigger className="group/account-group bg-muted hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/30 dark:bg-card dark:hover:bg-input relative grid min-h-11 flex-1 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 border border-transparent py-1.5 pr-10 pl-3 text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-inset disabled:pointer-events-none disabled:opacity-50">
         <span className="flex min-w-0 items-center gap-2">
           <span
             aria-hidden="true"

--- a/web/src/routes/_user/household/$householdId/accounts/-components/edit-account.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/edit-account.tsx
@@ -28,21 +28,11 @@ import {
   FieldLabel,
 } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-} from '@/components/ui/combobox'
-import {
-  ACCOUNT_CATEGORY_OPTIONS,
-  ACCOUNT_CATEGORY_APPLICABLE_TYPES,
-} from '@/constant'
+import { ACCOUNT_CATEGORY_APPLICABLE_TYPES } from '@/constant'
 import { commitMutationResult } from '@/lib/relay'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { getLogoDomainURL } from '@/lib/logo'
+import { AccountCategoryPicker } from './account-category-picker'
 
 const formSchema = z.object({
   name: z
@@ -162,40 +152,18 @@ export function EditAccount({ fragmentRef }: EditAccountProps) {
                 children={(field) => {
                   const isInvalid =
                     field.state.meta.isTouched && !field.state.meta.isValid
-                  const selectedItem =
-                    ACCOUNT_CATEGORY_OPTIONS.find(
-                      (o) => o.value === field.state.value,
-                    ) ?? null
                   return (
                     <Field data-invalid={isInvalid}>
                       <FieldLabel htmlFor={field.name}>
                         Category (optional)
                       </FieldLabel>
-                      <Combobox
-                        items={ACCOUNT_CATEGORY_OPTIONS}
-                        value={selectedItem}
-                        onValueChange={(item) =>
-                          field.handleChange(item?.value ?? '')
-                        }
-                      >
-                        <ComboboxInput
-                          id={field.name}
-                          name={field.name}
-                          placeholder="None (Taxable)"
-                          onBlur={field.handleBlur}
-                          aria-invalid={isInvalid}
-                        />
-                        <ComboboxContent>
-                          <ComboboxEmpty>No items found.</ComboboxEmpty>
-                          <ComboboxList>
-                            {(item: { value: string; label: string }) => (
-                              <ComboboxItem key={item.value} value={item}>
-                                {item.label}
-                              </ComboboxItem>
-                            )}
-                          </ComboboxList>
-                        </ComboboxContent>
-                      </Combobox>
+                      <AccountCategoryPicker
+                        name={field.name}
+                        value={field.state.value}
+                        onValueChange={field.handleChange}
+                        onBlur={field.handleBlur}
+                        invalid={isInvalid}
+                      />
                       {isInvalid && (
                         <FieldError errors={field.state.meta.errors} />
                       )}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/__generated__/editTransactionDialogCategoriesFragment.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/__generated__/editTransactionDialogCategoriesFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e9a4237083d4cf1f0210f251183490e0>>
+ * @generated SignedSource<<7d90756950c141879727d548740f95c1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type editTransactionDialogCategoriesFragment$data = {
   readonly transactionCategories: {
     readonly edges: ReadonlyArray<{
       readonly node: {
+        readonly icon: string;
         readonly id: string;
         readonly name: string;
         readonly type: TransactionCategoryType;
@@ -78,6 +79,13 @@ const node: ReaderFragment = {
                   "kind": "ScalarField",
                   "name": "type",
                   "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "icon",
+                  "storageKey": null
                 }
               ],
               "storageKey": null
@@ -93,6 +101,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "ee2b2330155fc9bf2be1b9723033748d";
+(node as any).hash = "1727d8a460b3b4f14396119d78988822";
 
 export default node;

--- a/web/src/routes/_user/household/$householdId/transactions/-components/__generated__/editTransactionDialogQuery.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/__generated__/editTransactionDialogQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3699967a6ec127547790ebe9f74947ea>>
+ * @generated SignedSource<<47fd37c6cd8a52032dbc114862be2607>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -89,26 +89,21 @@ v7 = {
   "name": "type",
   "storageKey": null
 },
-v8 = [
-  (v3/*: any*/),
-  (v6/*: any*/),
-  (v7/*: any*/)
-],
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "amount",
   "storageKey": null
 },
-v10 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "symbol",
   "storageKey": null
 },
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "concreteType": "HouseholdCurrency",
@@ -127,11 +122,11 @@ v11 = {
   ],
   "storageKey": null
 },
-v12 = [
+v11 = [
   (v6/*: any*/),
   (v3/*: any*/)
 ],
-v13 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -236,7 +231,11 @@ return {
                 "kind": "LinkedField",
                 "name": "category",
                 "plural": false,
-                "selections": (v8/*: any*/),
+                "selections": [
+                  (v3/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/)
+                ],
                 "storageKey": null
               },
               {
@@ -248,7 +247,7 @@ return {
                 "plural": true,
                 "selections": [
                   (v3/*: any*/),
-                  (v9/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -265,8 +264,8 @@ return {
                     "plural": false,
                     "selections": [
                       (v6/*: any*/),
+                      (v9/*: any*/),
                       (v10/*: any*/),
-                      (v11/*: any*/),
                       (v3/*: any*/),
                       {
                         "alias": null,
@@ -299,7 +298,7 @@ return {
                         "kind": "LinkedField",
                         "name": "category",
                         "plural": false,
-                        "selections": (v12/*: any*/),
+                        "selections": (v11/*: any*/),
                         "storageKey": null
                       },
                       (v4/*: any*/)
@@ -318,7 +317,7 @@ return {
                 "plural": true,
                 "selections": [
                   (v3/*: any*/),
-                  (v9/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -328,7 +327,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v6/*: any*/),
-                      (v11/*: any*/),
+                      (v10/*: any*/),
                       (v3/*: any*/)
                     ],
                     "storageKey": null
@@ -353,7 +352,7 @@ return {
                         "selections": [
                           (v6/*: any*/),
                           (v7/*: any*/),
-                          (v13/*: any*/),
+                          (v12/*: any*/),
                           (v3/*: any*/)
                         ],
                         "storageKey": null
@@ -395,7 +394,12 @@ return {
                 "kind": "LinkedField",
                 "name": "node",
                 "plural": false,
-                "selections": (v8/*: any*/),
+                "selections": [
+                  (v3/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v12/*: any*/)
+                ],
                 "storageKey": null
               }
             ],
@@ -447,7 +451,7 @@ return {
                       (v3/*: any*/),
                       (v6/*: any*/),
                       (v7/*: any*/),
-                      (v13/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -455,7 +459,7 @@ return {
                         "name": "value",
                         "storageKey": null
                       },
-                      (v11/*: any*/),
+                      (v10/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -463,7 +467,7 @@ return {
                         "kind": "LinkedField",
                         "name": "user",
                         "plural": false,
-                        "selections": (v12/*: any*/),
+                        "selections": (v11/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -476,7 +480,7 @@ return {
                         "selections": [
                           (v3/*: any*/),
                           (v6/*: any*/),
-                          (v10/*: any*/)
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -496,12 +500,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b40b1ae75fcee5549a23ba6f2c7f1304",
+    "cacheID": "613c9f0f59d36cea950496f8652d806f",
     "id": null,
     "metadata": {},
     "name": "editTransactionDialogQuery",
     "operationKind": "query",
-    "text": "query editTransactionDialogQuery(\n  $transactionId: ID!\n) {\n  node(id: $transactionId) {\n    __typename\n    ... on Transaction {\n      ...editTransactionDialogTransactionFragment\n    }\n    id\n  }\n  ...editTransactionDialogCategoriesFragment\n  household {\n    ...editTransactionDialogHouseholdFragment\n    id\n  }\n}\n\nfragment editTransactionDialogCategoriesFragment on Query {\n  transactionCategories {\n    edges {\n      node {\n        id\n        name\n        type\n      }\n    }\n  }\n}\n\nfragment editTransactionDialogHouseholdFragment on Household {\n  accounts(where: {archived: false}) {\n    edges {\n      node {\n        id\n        name\n        type\n        icon\n        value\n        householdCurrency {\n          code\n          id\n        }\n        user {\n          name\n          id\n        }\n        investments {\n          id\n          name\n          symbol\n        }\n      }\n    }\n  }\n}\n\nfragment editTransactionDialogTransactionFragment on Transaction {\n  id\n  description\n  datetime\n  categoryID\n  excludeFromReports\n  category {\n    id\n    name\n    type\n  }\n  investmentLots {\n    ...investmentLotCardFragment\n    id\n    amount\n    price\n    investment {\n      id\n      account {\n        id\n      }\n    }\n  }\n  transactionEntries {\n    ...transactionEntryCardFragment\n    id\n    amount\n    account {\n      id\n    }\n  }\n}\n\nfragment investmentLotCardFragment on InvestmentLot {\n  id\n  amount\n  price\n  investment {\n    name\n    symbol\n    householdCurrency {\n      code\n      id\n    }\n    id\n  }\n  transaction {\n    id\n    category {\n      name\n      id\n    }\n    datetime\n  }\n}\n\nfragment transactionEntryCardFragment on TransactionEntry {\n  id\n  amount\n  account {\n    name\n    householdCurrency {\n      code\n      id\n    }\n    id\n  }\n  transaction {\n    id\n    excludeFromReports\n    category {\n      name\n      type\n      icon\n      id\n    }\n    datetime\n  }\n}\n"
+    "text": "query editTransactionDialogQuery(\n  $transactionId: ID!\n) {\n  node(id: $transactionId) {\n    __typename\n    ... on Transaction {\n      ...editTransactionDialogTransactionFragment\n    }\n    id\n  }\n  ...editTransactionDialogCategoriesFragment\n  household {\n    ...editTransactionDialogHouseholdFragment\n    id\n  }\n}\n\nfragment editTransactionDialogCategoriesFragment on Query {\n  transactionCategories {\n    edges {\n      node {\n        id\n        name\n        type\n        icon\n      }\n    }\n  }\n}\n\nfragment editTransactionDialogHouseholdFragment on Household {\n  accounts(where: {archived: false}) {\n    edges {\n      node {\n        id\n        name\n        type\n        icon\n        value\n        householdCurrency {\n          code\n          id\n        }\n        user {\n          name\n          id\n        }\n        investments {\n          id\n          name\n          symbol\n        }\n      }\n    }\n  }\n}\n\nfragment editTransactionDialogTransactionFragment on Transaction {\n  id\n  description\n  datetime\n  categoryID\n  excludeFromReports\n  category {\n    id\n    name\n    type\n  }\n  investmentLots {\n    ...investmentLotCardFragment\n    id\n    amount\n    price\n    investment {\n      id\n      account {\n        id\n      }\n    }\n  }\n  transactionEntries {\n    ...transactionEntryCardFragment\n    id\n    amount\n    account {\n      id\n    }\n  }\n}\n\nfragment investmentLotCardFragment on InvestmentLot {\n  id\n  amount\n  price\n  investment {\n    name\n    symbol\n    householdCurrency {\n      code\n      id\n    }\n    id\n  }\n  transaction {\n    id\n    category {\n      name\n      id\n    }\n    datetime\n  }\n}\n\nfragment transactionEntryCardFragment on TransactionEntry {\n  id\n  amount\n  account {\n    name\n    householdCurrency {\n      code\n      id\n    }\n    id\n  }\n  transaction {\n    id\n    excludeFromReports\n    category {\n      name\n      type\n      icon\n      id\n    }\n    datetime\n  }\n}\n"
   }
 };
 })();

--- a/web/src/routes/_user/household/$householdId/transactions/-components/edit-transaction-dialog.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/edit-transaction-dialog.tsx
@@ -49,14 +49,6 @@ import {
   FieldSet,
 } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-} from '@/components/ui/combobox'
 import { Calendar } from '@/components/ui/calendar'
 import {
   DropdownMenu,
@@ -75,6 +67,7 @@ import currency from 'currency.js'
 import { Separator } from '@/components/ui/separator'
 import { identity } from 'lodash-es'
 import { NodeType, useDeleteNode } from '@/lib/relay'
+import { TransactionCategoryPicker } from './transaction-category-picker'
 
 const editTransactionDialogUpdateMutation = graphql`
   mutation editTransactionDialogUpdateMutation(
@@ -150,6 +143,7 @@ const editTransactionDialogCategoriesFragment = graphql`
           id
           name
           type
+          icon
         }
       }
     }
@@ -585,36 +579,14 @@ export function EditTransactionDialog({
                 return (
                   <Field data-invalid={isInvalid}>
                     <FieldLabel htmlFor={field.name}>Category</FieldLabel>
-                    <Combobox
-                      items={allCategories.map((cat) => cat.id)}
-                      itemToStringLabel={(item) =>
-                        allCategories.find((cat) => cat.id === item)?.name || ''
-                      }
+                    <TransactionCategoryPicker
+                      categories={allCategories}
+                      name={field.name}
                       value={field.state.value}
-                      onValueChange={(value) => {
-                        field.handleChange(value || '')
-                      }}
-                    >
-                      <ComboboxInput
-                        data-1p-ignore
-                        id={field.name}
-                        name={field.name}
-                        placeholder="Select a category"
-                        onBlur={field.handleBlur}
-                        aria-invalid={isInvalid}
-                      />
-                      <ComboboxContent>
-                        <ComboboxEmpty>No items found.</ComboboxEmpty>
-                        <ComboboxList>
-                          {(item: string) => (
-                            <ComboboxItem key={item} value={item}>
-                              {allCategories.find((cat) => cat.id === item)
-                                ?.name || ''}
-                            </ComboboxItem>
-                          )}
-                        </ComboboxList>
-                      </ComboboxContent>
-                    </Combobox>
+                      onValueChange={field.handleChange}
+                      onBlur={field.handleBlur}
+                      invalid={isInvalid}
+                    />
                     {isInvalid && (
                       <FieldError errors={field.state.meta.errors} />
                     )}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/selection-rows.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/selection-rows.test.tsx
@@ -2,7 +2,7 @@
 import { act, cleanup, render, screen } from '@testing-library/react'
 import { useEffect } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
-import { SelectionRows } from './selection-rows'
+import { SelectionRows } from '@/components/selection-rows'
 
 vi.mock('@/components/ui/scroll-area', () => ({
   ScrollArea: ({ children }: { children: React.ReactNode }) => (

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.tsx
@@ -1,4 +1,4 @@
-import { SelectionRows } from './selection-rows'
+import { SelectionRows } from '@/components/selection-rows'
 import { Tabs } from '@base-ui/react/tabs'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { graphql, useFragment } from 'react-relay'

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.test.tsx
@@ -9,7 +9,7 @@ const mobileState = vi.hoisted(() => ({ value: true }))
 vi.mock('@/hooks/use-mobile', () => ({
   useIsMobile: () => mobileState.value,
 }))
-vi.mock('./selection-rows', () => ({
+vi.mock('@/components/selection-rows', () => ({
   SelectionRows: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-category-picker.tsx
@@ -1,18 +1,5 @@
 import { CategoryIcon } from '@/components/category-icon'
-import { SelectionRows } from './selection-rows'
-import { useIsMobile } from '@/hooks/use-mobile'
-import { ChevronDownIcon } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
-import { Button } from '@/components/ui/button'
-import { ScrollArea } from '@/components/ui/scroll-area'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
+import { ResponsiveSelectionPicker } from '@/components/responsive-selection-picker'
 
 type TransactionCategoryPickerProps = {
   categories: ReadonlyArray<{
@@ -36,140 +23,21 @@ export function TransactionCategoryPicker({
   onBlur,
   invalid,
 }: TransactionCategoryPickerProps) {
-  const isMobile = useIsMobile()
-  const [editing, setEditing] = useState(false)
-  const expanded = !value || editing
-  const summaryRef = useRef<HTMLButtonElement>(null)
-  const wasExpanded = useRef(expanded)
-  const selected = categories.find((category) => category.id === value)
-
-  useEffect(() => {
-    if (isMobile && wasExpanded.current && !expanded) {
-      summaryRef.current?.focus({ preventScroll: true })
-    }
-    wasExpanded.current = expanded
-  }, [expanded, isMobile])
-
-  if (isMobile) {
-    if (!expanded && selected) {
-      return (
-        <button
-          ref={summaryRef}
-          type="button"
-          id={name}
-          aria-expanded={false}
-          aria-label={`Category: ${selected.name}`}
-          onClick={() => setEditing(true)}
-          className="border-input bg-background focus-visible:outline-ring flex min-h-9 w-full items-center gap-2 border px-2 py-1.5 text-left focus-visible:outline-2 focus-visible:outline-offset-2"
-        >
-          <CategoryDetails category={selected} />
-          <ChevronDownIcon className="size-4 shrink-0" aria-hidden="true" />
-        </button>
-      )
-    }
-
-    return (
-      <fieldset
-        id={name}
-        aria-invalid={invalid}
-        className="m-0 min-w-0 border-0 p-0"
-        onBlur={(event) => {
-          if (!event.currentTarget.contains(event.relatedTarget)) onBlur()
-        }}
-      >
-        <legend className="sr-only">Category</legend>
-        {categories.length === 0 ? (
-          <p className="text-muted-foreground w-full text-xs">
-            No categories available.
-          </p>
-        ) : (
-          <SelectionRows label="Categories">
-            {categories.map((category) => (
-              <label
-                key={category.id}
-                className="border-input bg-background has-checked:border-primary has-focus-visible:outline-ring flex min-h-9 max-w-64 min-w-0 cursor-pointer items-center gap-2 border px-2 py-1.5 has-focus-visible:outline-2 has-focus-visible:-outline-offset-2"
-              >
-                <input
-                  type="radio"
-                  name={name}
-                  value={category.id}
-                  checked={value === category.id}
-                  onChange={() => {
-                    onValueChange(category.id)
-                    setEditing(false)
-                  }}
-                  onClick={() => {
-                    if (value === category.id) setEditing(false)
-                  }}
-                  aria-invalid={invalid}
-                  className="sr-only"
-                />
-                <CategoryDetails category={category} />
-              </label>
-            ))}
-          </SelectionRows>
-        )}
-      </fieldset>
-    )
-  }
-
   return (
-    <DropdownMenu
-      onOpenChange={(open) => {
-        if (!open) onBlur()
-      }}
-    >
-      <DropdownMenuTrigger
-        render={
-          <Button
-            id={name}
-            name={name}
-            type="button"
-            variant="outline"
-            aria-invalid={invalid}
-            aria-label={`Category: ${selected?.name ?? 'Select a category'}`}
-            className="h-auto min-h-9 w-full justify-between px-2 py-1.5 text-left font-normal"
-          />
-        }
-      >
-        {selected ? (
-          <span className="flex min-w-0 flex-1 items-center gap-2">
-            <CategoryDetails category={selected} />
-          </span>
-        ) : (
-          <span className="text-muted-foreground min-w-0 flex-1 truncate text-left">
-            Select a category
-          </span>
-        )}
-        <ChevronDownIcon data-icon="inline-end" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent className="max-h-none overflow-hidden p-0">
-        <ScrollArea className="max-h-80 [&_[data-slot=scroll-area-viewport]]:max-h-80">
-          <div className="p-1">
-            <DropdownMenuGroup>
-              <DropdownMenuRadioGroup
-                value={value}
-                onValueChange={(nextValue) => {
-                  if (typeof nextValue === 'string') onValueChange(nextValue)
-                }}
-              >
-                {categories.map((category) => (
-                  <DropdownMenuRadioItem
-                    key={category.id}
-                    value={category.id}
-                    aria-label={category.name}
-                    closeOnClick
-                    className="min-h-9"
-                  >
-                    <CategoryDetails category={category} />
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuGroup>
-          </div>
-        </ScrollArea>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <ResponsiveSelectionPicker
+      items={categories}
+      name={name}
+      value={value}
+      label="Category"
+      placeholder="Select a category"
+      emptyMessage="No categories available."
+      getValue={(category) => category.id}
+      getLabel={(category) => category.name}
+      renderItem={(category) => <CategoryDetails category={category} />}
+      onValueChange={onValueChange}
+      onBlur={onBlur}
+      invalid={invalid}
+    />
   )
 }
 

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.test.tsx
@@ -42,7 +42,6 @@ vi.mock('@/hooks/use-currency', () => ({
 
 const transaction = {
   datetime: '2026-09-07T12:00:00Z',
-  description: 'Dinner',
   excludeFromReports: false,
   category: { icon: null, name: 'Restaurant', type: 'expense' },
   transactionEntries: [

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.tsx
@@ -236,7 +236,7 @@ export function TransactionDialogPreview({
           <FieldGroup>
             <PreviewField label="Description" />
             <PreviewField label="Date" />
-            <PreviewField label="Category" />
+            <PreviewField label="Category" controlClassName="h-9" />
             <FieldSet data-slot="transaction-dialog-preview-field">
               <FieldLegend variant="label">Options</FieldLegend>
               <FieldGroup data-slot="checkbox-group">
@@ -261,11 +261,19 @@ export function TransactionDialogPreview({
   )
 }
 
-function PreviewField({ label }: { label: string }) {
+function PreviewField({
+  label,
+  controlClassName = 'h-7',
+}: {
+  label: string
+  controlClassName?: string
+}) {
   return (
     <Field data-slot="transaction-dialog-preview-field">
       <FieldLabel>{label}</FieldLabel>
-      <Skeleton className="h-7 w-full motion-reduce:animate-none" />
+      <Skeleton
+        className={cn('w-full motion-reduce:animate-none', controlClassName)}
+      />
     </Field>
   )
 }

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.tsx
@@ -101,7 +101,7 @@ export function TransactionDialogPreview({
           lot,
         })),
       ]
-    : null
+    : []
 
   return (
     <>
@@ -114,7 +114,7 @@ export function TransactionDialogPreview({
       </DialogHeader>
 
       <div className="border-border [a]:hover:bg-muted group/item focus-visible:border-ring focus-visible:ring-ring/50 flex w-full flex-wrap items-center rounded-md border text-xs/relaxed outline-none focus-visible:ring-[3px]">
-        {previewItems
+        {transaction
           ? previewItems.map((item, index) => (
               <Fragment key={item.id}>
                 {index !== 0 && <Separator />}
@@ -127,14 +127,14 @@ export function TransactionDialogPreview({
                   >
                     <ItemMedia variant="image" className="rounded-full">
                       <CategoryIcon
-                        type={transaction!.category.type}
-                        icon={transaction!.category.icon}
+                        type={transaction.category.type}
+                        icon={transaction.category.icon}
                       />
                     </ItemMedia>
                     <ItemContent className="gap-px">
                       <ItemTitle>
-                        <span>{transaction!.category.name}</span>
-                        {transaction!.excludeFromReports && (
+                        <span>{transaction.category.name}</span>
+                        {transaction.excludeFromReports && (
                           <Badge className="h-4 px-1.5">Excluded</Badge>
                         )}
                       </ItemTitle>
@@ -170,7 +170,7 @@ export function TransactionDialogPreview({
                       </Avatar>
                     </ItemMedia>
                     <ItemContent className="gap-px">
-                      <ItemTitle>{transaction!.category.name}</ItemTitle>
+                      <ItemTitle>{transaction.category.name}</ItemTitle>
                       <ItemDescription>
                         {isPrivacyModeEnabled
                           ? '•••••••'

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.test.tsx
@@ -13,7 +13,7 @@ vi.mock('@/lib/logo', () => ({
   getLogoCryptoURL: () => '',
   getLogoTickerURL: () => '',
 }))
-vi.mock('./selection-rows', () => ({
+vi.mock('@/components/selection-rows', () => ({
   SelectionRows: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { ChartNoAxesCombinedIcon, ChevronDownIcon } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import { SelectionRows } from './selection-rows'
+import { SelectionRows } from '@/components/selection-rows'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { getLogoCryptoURL, getLogoTickerURL } from '@/lib/logo'
 import { cn } from '@/lib/utils'

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
@@ -109,6 +109,9 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
   const [editQueryRef, loadEditQuery, disposeEditQuery] =
     useQueryLoader<editTransactionDialogQuery>(EditTransactionDialogQuery)
   const loadedTransactionIdRef = useRef<string | null>(null)
+  const [retainedTransactionId, setRetainedTransactionId] = useState<
+    string | null
+  >(null)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [direction, setDirection] = useState<'ASC' | 'DESC'>('DESC')
   const [isSorting, startTransition] = useTransition()
@@ -117,6 +120,7 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
       if (loadedTransactionIdRef.current === transactionId) return
 
       loadedTransactionIdRef.current = transactionId
+      setRetainedTransactionId(transactionId)
       loadEditQuery({ transactionId }, { fetchPolicy: 'store-or-network' })
     },
     [loadEditQuery],
@@ -138,12 +142,15 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
   useEffect(() => {
     if (editTransactionId) {
       preloadTransaction(editTransactionId)
-      return
     }
+  }, [editTransactionId, preloadTransaction])
 
+  const finishClosingTransaction = useCallback(() => {
+    if (editTransactionId) return
     loadedTransactionIdRef.current = null
+    setRetainedTransactionId(null)
     disposeEditQuery()
-  }, [disposeEditQuery, editTransactionId, preloadTransaction])
+  }, [disposeEditQuery, editTransactionId])
   const changeSort = useCallback(
     (nextDirection: 'ASC' | 'DESC') => {
       startTransition(() => {
@@ -277,10 +284,12 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
       {list}
       <TransactionDetailDialog
         transactionId={editTransactionId}
+        retainedTransactionId={editTransactionId ?? retainedTransactionId}
         queryRef={editQueryRef}
         previewRef={
           transactions.find(
-            (transaction) => transaction.id === editTransactionId,
+            (transaction) =>
+              transaction.id === (editTransactionId ?? retainedTransactionId),
           ) ?? null
         }
         onClose={() => {
@@ -293,6 +302,7 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
             }),
           })
         }}
+        onCloseComplete={finishClosingTransaction}
       />
     </>
   )
@@ -300,19 +310,25 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
 
 type TransactionDetailDialogProps = {
   transactionId: string | null
+  retainedTransactionId: string | null
   queryRef: PreloadedQuery<editTransactionDialogQuery> | null | undefined
   previewRef: transactionDialogPreviewFragment$key | null
   onClose: () => void
+  onCloseComplete: () => void
 }
 
 function TransactionDetailDialog({
   transactionId,
+  retainedTransactionId,
   queryRef,
   previewRef,
   onClose,
+  onCloseComplete,
 }: TransactionDetailDialogProps) {
   const matchingQueryRef =
-    transactionId === queryRef?.variables.transactionId ? queryRef : null
+    retainedTransactionId === queryRef?.variables.transactionId
+      ? queryRef
+      : null
 
   return (
     <Dialog
@@ -320,10 +336,13 @@ function TransactionDetailDialog({
       onOpenChange={(open) => {
         if (!open) onClose()
       }}
+      onOpenChangeComplete={(open) => {
+        if (!open) onCloseComplete()
+      }}
     >
       <DialogContent>
         <ErrorBoundary
-          key={transactionId ?? 'closed'}
+          key={retainedTransactionId ?? 'closed'}
           fallback={
             <>
               <DialogHeader>
@@ -345,7 +364,7 @@ function TransactionDetailDialog({
               fallback={<TransactionDialogPreview fragmentRef={previewRef} />}
             >
               <EditTransactionDialog
-                key={transactionId}
+                key={retainedTransactionId}
                 queryRef={matchingQueryRef}
               />
             </Suspense>


### PR DESCRIPTION
## Summary
- retain the active Relay query and cached preview through the dialog exit animation so closing never changes height
- reuse one responsive selection picker for transaction categories and account category editing
- keep transaction URL search parameters shareable across transactions embedded in account, investment, and category routes
- calculate liability allocations against total liabilities and label the basis correctly
- keep account allocation rails visible on light-mode accordion hover
- simplify cached transaction preview narrowing

## Verification
- Relay compiler: pass
- TypeScript, ESLint, and Prettier checks: pass
- Vitest: 14 files, 67 tests pass
- Vite production build: pass
- Browser: desktop loading/resolved/closing height stays 501px; mobile stays 537px
- Browser: account detail and nested transaction dialog load without route errors
- Browser: transaction and account category pickers verified on desktop and mobile
- Browser: liability percentages and light/dark accordion hover verified