### PR TITLE
Fix decimal inputs and account detail routing

### DIFF
--- a/web/src/components/currency-input.test.tsx
+++ b/web/src/components/currency-input.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { CurrencyInput } from './currency-input'
+
+afterEach(cleanup)
+
+it('keeps the decimal mobile keyboard when negative values are allowed', () => {
+  render(
+    <CurrencyInput
+      locale="en-US"
+      currency="USD"
+      allowNegative
+      onValueChange={() => {}}
+    />,
+  )
+
+  expect(screen.getByRole('textbox').getAttribute('inputmode')).toBe('decimal')
+})
+
+it('parses locale decimal separators before reporting the numeric value', () => {
+  const onValueChange = vi.fn()
+  render(
+    <CurrencyInput
+      locale="de-DE"
+      currency="EUR"
+      onValueChange={onValueChange}
+    />,
+  )
+
+  fireEvent.change(screen.getByRole('textbox'), {
+    target: { value: '12,34' },
+  })
+
+  expect(onValueChange).toHaveBeenLastCalledWith({
+    floatValue: 12.34,
+    value: '12,34',
+  })
+})

--- a/web/src/components/currency-input.tsx
+++ b/web/src/components/currency-input.tsx
@@ -74,10 +74,12 @@ export function CurrencyInput({
       const cleaned = validate(e.target.value)
       setRawValue(cleaned)
 
-      const floatValue = cleaned === '' ? undefined : parseFloat(cleaned)
+      const normalizedValue = cleaned.replace(decimalSeparator, '.')
+      const floatValue =
+        cleaned === '' ? undefined : parseFloat(normalizedValue)
       onValueChange?.({ floatValue, value: cleaned })
     },
-    [validate, onValueChange],
+    [decimalSeparator, validate, onValueChange],
   )
 
   return (
@@ -95,7 +97,7 @@ export function CurrencyInput({
       <input
         data-slot="input"
         type="text"
-        inputMode={allowNegative ? 'numeric' : 'decimal'}
+        inputMode="decimal"
         value={rawValue}
         onChange={handleChange}
         className={cn(

--- a/web/src/routes/_user/household/$householdId/investments/-components/new-investment.tsx
+++ b/web/src/routes/_user/household/$householdId/investments/-components/new-investment.tsx
@@ -601,6 +601,7 @@ export function NewInvestment({
                     <Input
                       type="number"
                       inputMode="decimal"
+                      step="any"
                       data-1p-ignore
                       id={field.name}
                       name={field.name}

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.test.tsx
@@ -16,6 +16,7 @@ const relay = vi.hoisted(() => ({
 const router = vi.hoisted(() => ({
   navigate: vi.fn(),
   search: { edit_transaction_id: null as string | null },
+  searchFrom: undefined as string | undefined,
 }))
 vi.mock('react-relay', () => ({
   usePaginationFragment: () => ({
@@ -32,7 +33,13 @@ vi.mock('react-relay', () => ({
 }))
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => router.navigate,
-  useSearch: () => router.search,
+  useSearch: (options?: {
+    from?: string
+    select?: (search: typeof router.search) => unknown
+  }) => {
+    router.searchFrom = options?.from
+    return options?.select ? options.select(router.search) : router.search
+  },
 }))
 vi.mock('relay-runtime', () => ({ graphql: () => ({}) }))
 vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => false }))
@@ -66,6 +73,13 @@ afterEach(() => {
   cleanup()
   vi.clearAllMocks()
   router.search.edit_transaction_id = null
+  router.searchFrom = undefined
+})
+
+it('reads dialog search state from the shared household route', () => {
+  render(<TransactionsList fragmentRef={fragmentRef} />)
+
+  expect(router.searchFrom).toBe('/_user/household/$householdId')
 })
 
 it('sorts through Relay with a fresh cursor and refreshes the active ASC connection on invalidation', () => {

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
@@ -101,8 +101,9 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
     >(transactionsListFragment, fragmentRef)
 
   const isMobile = useIsMobile()
-  const search = useSearch({
-    from: '/_user/household/$householdId/transactions',
+  const editTransactionId = useSearch({
+    from: '/_user/household/$householdId',
+    select: (search) => search.edit_transaction_id,
   })
   const navigate = useNavigate()
   const [editQueryRef, loadEditQuery, disposeEditQuery] =
@@ -135,14 +136,14 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
     [navigate, preloadTransaction],
   )
   useEffect(() => {
-    if (search.edit_transaction_id) {
-      preloadTransaction(search.edit_transaction_id)
+    if (editTransactionId) {
+      preloadTransaction(editTransactionId)
       return
     }
 
     loadedTransactionIdRef.current = null
     disposeEditQuery()
-  }, [disposeEditQuery, preloadTransaction, search.edit_transaction_id])
+  }, [disposeEditQuery, editTransactionId, preloadTransaction])
   const changeSort = useCallback(
     (nextDirection: 'ASC' | 'DESC') => {
       startTransition(() => {
@@ -275,11 +276,11 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
     <>
       {list}
       <TransactionDetailDialog
-        transactionId={search.edit_transaction_id}
+        transactionId={editTransactionId}
         queryRef={editQueryRef}
         previewRef={
           transactions.find(
-            (transaction) => transaction.id === search.edit_transaction_id,
+            (transaction) => transaction.id === editTransactionId,
           ) ?? null
         }
         onClose={() => {


### PR DESCRIPTION
## Summary
- keep decimal keyboards available for account balance entry on mobile and normalize locale decimal separators
- allow fractional investment quantities through native browser validation
- scope the shared transaction list to the household route and select only the transaction dialog search parameter
- add regressions for mobile decimal input, locale parsing, and shared-route search state

## Verification
- cd web && pnpm test
- cd web && pnpm check
- cd web && pnpm build
- live account-detail verification against the worktree preview