### PR TITLE
Fix liability group allocation basis

### DIFF
--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.test.ts
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { calculateAllocationPercentage } from './account-ledger-utils'
+import {
+  calculateAllocationPercentage,
+  getAccountGroupAllocation,
+} from './account-ledger-utils'
 
 describe('calculateAllocationPercentage', () => {
   it('calculates a liability share against the total liability magnitude', () => {
@@ -10,5 +13,14 @@ describe('calculateAllocationPercentage', () => {
   it('handles mixed signs and empty totals safely', () => {
     expect(calculateAllocationPercentage(-250, 1000)).toBe(25)
     expect(calculateAllocationPercentage(250, 0)).toBe(0)
+  })
+})
+
+describe('getAccountGroupAllocation', () => {
+  it('calculates a liability group against total assets', () => {
+    expect(getAccountGroupAllocation(-250, 2000)).toEqual({
+      share: 12.5,
+      basis: 'assets',
+    })
   })
 })

--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.ts
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.ts
@@ -27,3 +27,13 @@ export function calculateAllocationPercentage(value: number, total: number) {
     return 0
   return (Math.abs(value) / Math.abs(total)) * 100
 }
+
+export function getAccountGroupAllocation(
+  groupValue: number,
+  totalAssets: number,
+) {
+  return {
+    share: calculateAllocationPercentage(groupValue, totalAssets),
+    basis: 'assets' as const,
+  }
+}

--- a/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/accounts-panel.tsx
@@ -24,6 +24,7 @@ import {
   ACCOUNT_TYPE_ACCENT_CLASSES,
   calculateAllocationPercentage,
   formatPercentageWithPrivacyMode,
+  getAccountGroupAllocation,
 } from './account-ledger-utils'
 import { AccountLedgerRow } from './account-ledger-row'
 import { NetWorthChart } from './net-worth-chart'
@@ -303,7 +304,6 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
   }, [accountItems])
 
   const assetsTotal = Math.abs(displayOptions[1].value.value)
-  const liabilitiesTotal = Math.abs(displayOptions[2].value.value)
 
   const getGroupLabel = (key: string) => {
     if (groupByOption === 'category') {
@@ -465,14 +465,8 @@ export function AccountsPanel({ fragmentRef }: AccountsListPageProps) {
             const isLiabilityGroup = accounts.every(
               ({ node }) => node.type === 'liability',
             )
-            const allocationTotal = isLiabilityGroup
-              ? liabilitiesTotal
-              : assetsTotal
-            const allocationBasis = isLiabilityGroup ? 'liabilities' : 'assets'
-            const groupShare = calculateAllocationPercentage(
-              groupTotal.value,
-              allocationTotal,
-            )
+            const { share: groupShare, basis: allocationBasis } =
+              getAccountGroupAllocation(groupTotal.value, assetsTotal)
             const groupTypes = new Set(accounts.map(({ node }) => node.type))
             const groupAccentClass =
               groupTypes.size === 1


### PR DESCRIPTION
## Summary
- calculate liability group share against total assets
- keep individual liability shares relative to the liability group total
- add regression coverage for the group allocation basis

## Verification
- `pnpm test -- src/routes/_user/household/$householdId/accounts/-components/account-ledger-utils.test.ts`
- `pnpm check`