### PR TITLE
Improve account type selection

### DIFF
--- a/web/src/components/ui/toggle-group.tsx
+++ b/web/src/components/ui/toggle-group.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react'
+import { Toggle as TogglePrimitive } from '@base-ui/react/toggle'
+import { ToggleGroup as ToggleGroupPrimitive } from '@base-ui/react/toggle-group'
+import { type VariantProps } from 'class-variance-authority'
+
+import { toggleVariants } from '@/components/ui/toggle-variants'
+import { cn } from '@/lib/utils'
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: 'horizontal' | 'vertical'
+  }
+>({
+  size: 'default',
+  variant: 'default',
+  spacing: 2,
+  orientation: 'horizontal',
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 2,
+  orientation = 'horizontal',
+  children,
+  ...props
+}: ToggleGroupPrimitive.Props &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: 'horizontal' | 'vertical'
+  }) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ '--gap': spacing } as React.CSSProperties}
+      className={cn(
+        'group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-md data-vertical:flex-col data-vertical:items-stretch data-[size=sm]:rounded-[min(var(--radius-md),8px)]',
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider
+        value={{ variant, size, spacing, orientation }}
+      >
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        'shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-md group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-md group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-md group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-md group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t',
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </TogglePrimitive>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/web/src/components/ui/toggle-variants.ts
+++ b/web/src/components/ui/toggle-variants.ts
@@ -1,0 +1,23 @@
+import { cva } from 'class-variance-authority'
+
+export const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-md text-xs font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        outline: 'border border-input bg-transparent hover:bg-muted',
+      },
+      size: {
+        default:
+          'h-7 min-w-7 px-2 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5',
+        sm: "h-6 min-w-6 rounded-[min(var(--radius-md),8px)] px-2 text-[0.625rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        lg: 'h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+)

--- a/web/src/components/ui/toggle.tsx
+++ b/web/src/components/ui/toggle.tsx
@@ -1,0 +1,22 @@
+import { Toggle as TogglePrimitive } from '@base-ui/react/toggle'
+import type { VariantProps } from 'class-variance-authority'
+
+import { toggleVariants } from '@/components/ui/toggle-variants'
+import { cn } from '@/lib/utils'
+
+function Toggle({
+  className,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle }

--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-type-picker.test.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-type-picker.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AccountTypePicker, type AccountType } from './account-type-picker'
+
+afterEach(cleanup)
+
+function Picker() {
+  const [value, setValue] = useState<AccountType | ''>('')
+
+  return (
+    <>
+      <span id="account-type-label">Type</span>
+      <AccountTypePicker
+        value={value}
+        onValueChange={setValue}
+        onBlur={vi.fn()}
+        labelledBy="account-type-label"
+      />
+    </>
+  )
+}
+
+describe('AccountTypePicker', () => {
+  it('shows every available account type without opening a menu', () => {
+    render(<Picker />)
+
+    expect(screen.getByRole('group', { name: 'Type' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Liquidity/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Investment/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Receivable/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Liability/ })).toBeTruthy()
+    expect(screen.queryByRole('combobox')).toBeNull()
+  })
+
+  it('keeps one account type selected', () => {
+    render(<Picker />)
+    const investment = screen.getByRole('button', { name: /Investment/ })
+
+    fireEvent.click(investment)
+    expect(investment.getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(investment)
+    expect(investment.getAttribute('aria-pressed')).toBe('true')
+  })
+})

--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-type-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-type-picker.tsx
@@ -1,0 +1,123 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  ChartNoAxesCombinedIcon,
+  CheckIcon,
+  CreditCardIcon,
+  HandCoinsIcon,
+  LandmarkIcon,
+} from 'lucide-react'
+
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { ACCOUNT_TYPE_DESCRIPTION, ACCOUNT_TYPE_LIST } from '@/constant'
+
+export type AccountType = (typeof ACCOUNT_TYPE_LIST)[number]
+
+const ACCOUNT_TYPE_PRESENTATION = {
+  liquidity: {
+    label: 'Liquidity',
+    icon: LandmarkIcon,
+    iconClassName: 'text-chart-liquidity',
+  },
+  investment: {
+    label: 'Investment',
+    icon: ChartNoAxesCombinedIcon,
+    iconClassName: 'text-chart-investment',
+  },
+  receivable: {
+    label: 'Receivable',
+    icon: HandCoinsIcon,
+    iconClassName: 'text-chart-receivable',
+  },
+  liability: {
+    label: 'Liability',
+    icon: CreditCardIcon,
+    iconClassName: 'text-chart-liability',
+  },
+} satisfies Record<
+  AccountType,
+  { label: string; icon: LucideIcon; iconClassName: string }
+>
+
+type AccountTypePickerProps = {
+  value: string
+  onValueChange: (value: AccountType) => void
+  onBlur: () => void
+  labelledBy: string
+  describedBy?: string
+  invalid?: boolean
+}
+
+function isAccountType(value: string | undefined): value is AccountType {
+  return ACCOUNT_TYPE_LIST.some((type) => type === value)
+}
+
+export function AccountTypePicker({
+  value,
+  onValueChange,
+  onBlur,
+  labelledBy,
+  describedBy,
+  invalid = false,
+}: AccountTypePickerProps) {
+  const selectedValue = isAccountType(value) ? [value] : []
+
+  return (
+    <ToggleGroup
+      value={selectedValue}
+      onValueChange={(values) => {
+        const nextValue = values[0]
+        if (isAccountType(nextValue)) {
+          onValueChange(nextValue)
+        }
+      }}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          onBlur()
+        }
+      }}
+      orientation="vertical"
+      variant="outline"
+      spacing={0}
+      aria-labelledby={labelledBy}
+      aria-describedby={describedBy}
+      aria-invalid={invalid}
+      className="w-full"
+    >
+      {ACCOUNT_TYPE_LIST.map((type) => {
+        const {
+          label,
+          icon: Icon,
+          iconClassName,
+        } = ACCOUNT_TYPE_PRESENTATION[type]
+
+        return (
+          <ToggleGroupItem
+            key={type}
+            value={type}
+            aria-invalid={invalid}
+            className="aria-pressed:bg-muted aria-pressed:hover:bg-muted aria-pressed:outline-foreground/40 h-auto min-h-12 w-full justify-start gap-3 px-3 py-2 text-left whitespace-normal aria-pressed:outline-1 aria-pressed:-outline-offset-1 aria-pressed:outline-solid"
+          >
+            <span
+              aria-hidden="true"
+              className="bg-muted ring-foreground/10 grid size-8 shrink-0 place-items-center ring-1"
+            >
+              <Icon className={iconClassName} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-xs/relaxed font-semibold">
+                {label}
+              </span>
+              <span className="text-muted-foreground block text-xs/normal font-normal">
+                {ACCOUNT_TYPE_DESCRIPTION[type]}
+              </span>
+            </span>
+            <CheckIcon
+              aria-hidden="true"
+              className="text-foreground shrink-0 opacity-0 group-aria-pressed/toggle:opacity-100"
+            />
+          </ToggleGroupItem>
+        )
+      })}
+    </ToggleGroup>
+  )
+}

--- a/web/src/routes/_user/household/$householdId/accounts/-components/new-account.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/new-account.tsx
@@ -3,7 +3,6 @@ import { useForm, useStore } from '@tanstack/react-form'
 import { toast } from 'sonner'
 import * as z from 'zod'
 import { useMutation } from 'react-relay'
-import { capitalize } from 'lodash-es'
 import currency from 'currency.js'
 import invariant from 'tiny-invariant'
 import { match } from 'ts-pattern'
@@ -28,6 +27,8 @@ import {
   FieldError,
   FieldGroup,
   FieldLabel,
+  FieldLegend,
+  FieldSet,
 } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import {
@@ -39,8 +40,6 @@ import {
   ComboboxList,
 } from '@/components/ui/combobox'
 import {
-  ACCOUNT_TYPE_DESCRIPTION,
-  ACCOUNT_TYPE_LIST,
   ACCOUNT_CATEGORY_OPTIONS,
   ACCOUNT_CATEGORY_APPLICABLE_TYPES,
 } from '@/constant'
@@ -55,6 +54,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { getLogoDomainURL } from '@/lib/logo'
 import { SUPPORTED_CURRENCIES } from '@/lib/currencies'
 import { useDisplayCurrency } from '@/hooks/use-display-currency'
+import { AccountTypePicker } from './account-type-picker'
 
 const formSchema = z.object({
   name: z
@@ -302,44 +302,28 @@ export function NewAccount() {
               children={(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
+                const labelId = `${field.name}-label`
+                const errorId = `${field.name}-error`
                 return (
-                  <Field data-invalid={isInvalid}>
-                    <FieldLabel htmlFor={field.name}>Type</FieldLabel>
-                    <Combobox
-                      items={ACCOUNT_TYPE_LIST}
+                  <FieldSet data-invalid={isInvalid}>
+                    <FieldLegend id={labelId} variant="label">
+                      Type
+                    </FieldLegend>
+                    <AccountTypePicker
                       value={field.state.value}
-                      onValueChange={(value) => field.handleChange(value || '')}
-                    >
-                      <ComboboxInput
-                        id={field.name}
-                        name={field.name}
-                        placeholder="Select a type"
-                        onBlur={field.handleBlur}
-                        aria-invalid={isInvalid}
-                        className="*:capitalize"
-                      />
-                      <ComboboxContent>
-                        <ComboboxEmpty>No items found.</ComboboxEmpty>
-                        <ComboboxList className="">
-                          {(item: string) => (
-                            <ComboboxItem
-                              key={item}
-                              value={item}
-                              className="flex flex-col items-start gap-0"
-                            >
-                              <span className="font-semibold">
-                                {capitalize(item)}
-                              </span>
-                              <span>{ACCOUNT_TYPE_DESCRIPTION[item]}</span>
-                            </ComboboxItem>
-                          )}
-                        </ComboboxList>
-                      </ComboboxContent>
-                    </Combobox>
+                      onValueChange={field.handleChange}
+                      onBlur={field.handleBlur}
+                      labelledBy={labelId}
+                      describedBy={isInvalid ? errorId : undefined}
+                      invalid={isInvalid}
+                    />
                     {isInvalid && (
-                      <FieldError errors={field.state.meta.errors} />
+                      <FieldError
+                        id={errorId}
+                        errors={field.state.meta.errors}
+                      />
                     )}
-                  </Field>
+                  </FieldSet>
                 )
               }}
             />


### PR DESCRIPTION
## Summary
- replace the account type dropdown with an always-visible single-select list
- add semantic icons and concise descriptions for each account type
- add reusable toggle primitives and interaction coverage
- use a neutral, complete selection outline consistent with the design system

## Validation
- pnpm check
- pnpm test (72 tests)
- pnpm build
- visually verified on desktop and mobile