### PR TITLE
Keep mobile content above the action dock

### DIFF
--- a/web/src/components/app-action-dock.tsx
+++ b/web/src/components/app-action-dock.tsx
@@ -38,7 +38,7 @@ export function AppActionDock({
   }
 
   return (
-    <div className="bg-background fixed inset-x-0 bottom-0 z-40 md:hidden">
+    <div className="bg-background z-40 shrink-0 md:hidden">
       <nav
         aria-label="Quick actions"
         className="border-border bg-background grid h-14 grid-cols-3 border-t"
@@ -59,8 +59,8 @@ export function AppActionDock({
           <DropdownMenuContent
             side="top"
             align="start"
-            sideOffset={12}
-            className="w-[min(18rem,calc(100vw-2rem))] rounded-none p-1 shadow-none"
+            sideOffset={8}
+            className="w-44 rounded-none p-1 shadow-none"
           >
             <div className="text-muted-foreground px-2 pt-1 pb-2 text-[0.625rem] tracking-wider uppercase">
               Go to

--- a/web/src/components/layouts/household-content-layout.tsx
+++ b/web/src/components/layouts/household-content-layout.tsx
@@ -13,7 +13,7 @@ function HouseholdContentLayout({
   className,
 }: HouseholdContentLayoutProps) {
   return (
-    <ScrollArea className="h-[calc(100vh-48px)] overflow-y-auto">
+    <ScrollArea className="h-full min-h-0 overflow-y-auto">
       <div className={cn('mx-auto max-w-5xl p-4', className)}>{children}</div>
     </ScrollArea>
   )

--- a/web/src/routes/_user/household/$householdId/route.tsx
+++ b/web/src/routes/_user/household/$householdId/route.tsx
@@ -239,9 +239,9 @@ function RouteComponent() {
             <DisplayCurrencyProvider householdRef={data.household}>
               <Hotkeys />
               <CommandMenu />
-              <SidebarProvider>
+              <SidebarProvider className="h-dvh min-h-0 overflow-hidden">
                 <AppSidebar fragmentRef={data} />
-                <SidebarInset>
+                <SidebarInset className="h-dvh min-h-0 overflow-hidden">
                   <header className="bg-background sticky top-0 z-10 flex h-10 shrink-0 items-stretch border-b transition-[width,height] ease-linear">
                     <SidebarTrigger className="cursor-pointer border-r" />
                     <div className="flex flex-1 items-center px-3">
@@ -338,15 +338,15 @@ function RouteComponent() {
                       </Button>
                     </div>
                   </header>
-                  <div className="flex flex-1 flex-col pb-[calc(3.5rem+env(safe-area-inset-bottom))] md:pb-0">
+                  <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                     <Outlet />
                   </div>
+                  <AppActionDock
+                    isMobile={isMobile}
+                    isRefreshing={isRefreshInFlight}
+                    onRefresh={handleRefreshAccountData}
+                  />
                 </SidebarInset>
-                <AppActionDock
-                  isMobile={isMobile}
-                  isRefreshing={isRefreshInFlight}
-                  onRefresh={handleRefreshAccountData}
-                />
 
                 {!isMobile && (
                   <FloatingLogTransactionWindow fragmentRef={data.household} />


### PR DESCRIPTION
Reserves the mobile action dock as part of the viewport layout so scrolling content cannot pass behind it. Also makes the Pages menu compact and updates shared household content scrolling to use the available layout height. Verified with Relay-aware frontend checks, 77 tests, a production build, and a live mobile smoke test.