### PR TITLE
Polish floating mobile action dock

### DIFF
--- a/web/src/components/app-action-dock.tsx
+++ b/web/src/components/app-action-dock.tsx
@@ -38,17 +38,17 @@ export function AppActionDock({
   }
 
   return (
-    <div className="bg-background z-40 shrink-0 md:hidden">
+    <div className="pointer-events-none fixed inset-x-0 bottom-[max(0.75rem,env(safe-area-inset-bottom))] z-40 md:hidden">
       <nav
         aria-label="Quick actions"
-        className="border-border bg-background grid h-14 grid-cols-3 border-t"
+        className="bg-background/90 ring-foreground/15 pointer-events-auto mx-auto grid h-14 w-[90%] grid-cols-[1fr_1.15fr_1fr] overflow-hidden rounded-none ring-1 backdrop-blur-xl"
       >
         <DropdownMenu>
           <DropdownMenuTrigger
             render={
               <Button
                 variant="ghost"
-                className="border-border h-full w-full flex-col gap-0.5 rounded-none border-0 border-r text-[0.625rem] font-medium tracking-wide uppercase"
+                className="h-full w-full flex-col gap-0.5 rounded-none border-0 text-[0.625rem] font-medium tracking-[0.01em]"
               >
                 <MenuIcon className="size-4" />
                 Pages
@@ -59,10 +59,10 @@ export function AppActionDock({
           <DropdownMenuContent
             side="top"
             align="start"
-            sideOffset={8}
-            className="w-44 rounded-none p-1 shadow-none"
+            sideOffset={16}
+            className="bg-popover/95 w-[min(18rem,calc(100vw-2rem))] overflow-hidden rounded-none p-1.5 shadow-none backdrop-blur-xl"
           >
-            <div className="text-muted-foreground px-2 pt-1 pb-2 text-[0.625rem] tracking-wider uppercase">
+            <div className="text-muted-foreground px-2 pt-1 pb-2 text-[0.625rem] font-medium tracking-[0.02em] uppercase">
               Go to
             </div>
             {NAV.map((item) => {
@@ -71,7 +71,7 @@ export function AppActionDock({
               return (
                 <DropdownMenuItem
                   key={item.name}
-                  className="min-h-9 rounded-none"
+                  className="min-h-10 rounded-none"
                   render={
                     <Link
                       {...item.link}
@@ -90,10 +90,10 @@ export function AppActionDock({
           </DropdownMenuContent>
         </DropdownMenu>
 
-        <div className="border-border border-r">
+        <div className="p-1.5">
           <Button
             onClick={() => openLogTransaction('expense')}
-            className="h-full w-full flex-col gap-0.5 rounded-none border-0 text-[0.625rem] font-semibold tracking-wide uppercase"
+            className="h-full w-full flex-col gap-0.5 rounded-none border-0 text-[0.625rem] font-semibold tracking-[0.01em]"
           >
             <PlusIcon className="size-4" />
             New entry
@@ -102,17 +102,29 @@ export function AppActionDock({
 
         <Button
           variant="ghost"
-          className="h-full w-full flex-col gap-0.5 rounded-none border-0 text-[0.625rem] font-medium tracking-wide uppercase"
+          className="h-full w-full flex-col gap-0.5 rounded-none border-0 text-[0.625rem] font-medium tracking-[0.01em]"
           onClick={onRefresh}
           disabled={isRefreshing}
         >
           <RefreshCwIcon
-            className={isRefreshing ? 'size-4 animate-spin' : 'size-4'}
+            className={
+              isRefreshing
+                ? 'size-4 animate-spin motion-reduce:animate-none'
+                : 'size-4'
+            }
           />
           {isRefreshing ? 'Syncing' : 'Sync data'}
         </Button>
       </nav>
-      <div className="bg-background h-[env(safe-area-inset-bottom)]" />
     </div>
+  )
+}
+
+export function MobileActionDockSpacer() {
+  return (
+    <div
+      aria-hidden="true"
+      className="h-[calc(5rem+env(safe-area-inset-bottom))] shrink-0 md:hidden"
+    />
   )
 }

--- a/web/src/components/layouts/household-content-layout.tsx
+++ b/web/src/components/layouts/household-content-layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { MobileActionDockSpacer } from '@/components/app-action-dock'
 import { cn } from '@/lib/utils'
 
 interface HouseholdContentLayoutProps {
@@ -14,7 +15,10 @@ function HouseholdContentLayout({
 }: HouseholdContentLayoutProps) {
   return (
     <ScrollArea className="h-full min-h-0 overflow-y-auto">
-      <div className={cn('mx-auto max-w-5xl p-4', className)}>{children}</div>
+      <div className={cn('mx-auto max-w-5xl p-4', className)}>
+        {children}
+        <MobileActionDockSpacer />
+      </div>
     </ScrollArea>
   )
 }

--- a/web/src/routes/_user/household/$householdId/transactions/-components/log-transaction.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/log-transaction.tsx
@@ -17,6 +17,7 @@ import { focusInitialTransactionControl } from './transaction-focus'
 import { useLogTransaction } from '@/hooks/use-log-transaction'
 import type { LogTransactionType } from '@/hooks/log-transaction-store'
 import { cn } from '@/lib/utils'
+import { MobileActionDockSpacer } from '@/components/app-action-dock'
 
 const logTransactionFragment = graphql`
   fragment logTransactionFragment on Household
@@ -162,6 +163,7 @@ export function LogTransaction({ fragmentRef }: NewTransactionProps) {
         {selectedType === 'buy' && <NewBuy fragmentRef={data} />}
         {selectedType === 'sell' && <NewSell fragmentRef={data} />}
         {selectedType === 'move' && <NewMove fragmentRef={data} />}
+        <MobileActionDockSpacer />
       </ScrollArea>
     </Item>
   )

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
@@ -52,6 +52,7 @@ import {
 import { TransactionDialogPreview } from './transaction-dialog-preview'
 import type { transactionDialogPreviewFragment$key } from './__generated__/transactionDialogPreviewFragment.graphql'
 import { useHouseholdViewScope } from '@/hooks/use-household-view-scope'
+import { MobileActionDockSpacer } from '@/components/app-action-dock'
 
 const transactionsListFragment = graphql`
   fragment transactionsListFragment on Household
@@ -282,6 +283,7 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
           </div>
         )}
         <div ref={ref}></div>
+        <MobileActionDockSpacer />
       </div>
     </ScrollArea>
   )


### PR DESCRIPTION
## Summary
- make the mobile action dock a square-edged, translucent 90%-width floating island
- keep the page picker square and allow page content to scroll behind the dock
- add reusable bottom clearance, including transaction-specific scroll areas, so final controls remain reachable

## Verification
- cd web && pnpm check
- cd web && pnpm test (77 tests)
- cd web && pnpm build