### PR TITLE
Narrow the Go To menu

### DIFF
--- a/web/src/components/command-menu.tsx
+++ b/web/src/components/command-menu.tsx
@@ -65,7 +65,7 @@ export function CommandMenu() {
   }
 
   return (
-    <CommandDialog open={open} onOpenChange={setOpen}>
+    <CommandDialog className="sm:max-w-80" open={open} onOpenChange={setOpen}>
       <Command>
         <CommandInput
           id={String(open) + String(random())}


### PR DESCRIPTION
## Summary
- reduce the desktop width of the Go To command menu from 384px to 320px
- preserve the existing responsive mobile width

## Verification
- `pnpm check`
- `pnpm test -- --run` (80 tests)
- browser verified at 320px rendered width