### PR TITLE
Respect iOS PWA safe areas

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <meta name="theme-color" content="#ffffff" />
     <meta name="description" content="beavermoney.app" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
 
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/web/src/components/app-action-dock.tsx
+++ b/web/src/components/app-action-dock.tsx
@@ -38,7 +38,7 @@ export function AppActionDock({
   }
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-[max(0.75rem,env(safe-area-inset-bottom))] z-40 md:hidden">
+    <div className="pointer-events-none fixed right-[var(--safe-area-inset-right)] bottom-[calc(var(--safe-area-inset-bottom)+0.75rem)] left-[var(--safe-area-inset-left)] z-40 md:hidden">
       <nav
         aria-label="Quick actions"
         className="bg-background/90 ring-foreground/15 pointer-events-auto mx-auto grid h-14 w-[90%] grid-cols-[1fr_1.15fr_1fr] overflow-hidden rounded-none ring-1 backdrop-blur-xl"
@@ -124,7 +124,7 @@ export function MobileActionDockSpacer() {
   return (
     <div
       aria-hidden="true"
-      className="h-[calc(5rem+env(safe-area-inset-bottom))] shrink-0 md:hidden"
+      className="h-[calc(5rem+var(--safe-area-inset-bottom))] shrink-0 md:hidden"
     />
   )
 }

--- a/web/src/routes/_user/household/$householdId/route.tsx
+++ b/web/src/routes/_user/household/$householdId/route.tsx
@@ -239,9 +239,9 @@ function RouteComponent() {
             <DisplayCurrencyProvider householdRef={data.household}>
               <Hotkeys />
               <CommandMenu />
-              <SidebarProvider className="h-dvh min-h-0 overflow-hidden">
+              <SidebarProvider className="h-[var(--safe-viewport-height)] min-h-0 overflow-hidden">
                 <AppSidebar fragmentRef={data} />
-                <SidebarInset className="h-dvh min-h-0 overflow-hidden">
+                <SidebarInset className="h-[var(--safe-viewport-height)] min-h-0 overflow-hidden">
                   <header className="bg-background sticky top-0 z-10 flex h-10 shrink-0 items-stretch border-b transition-[width,height] ease-linear">
                     <SidebarTrigger className="cursor-pointer border-r" />
                     <div className="flex flex-1 items-center px-3">

--- a/web/src/routes/_user/household/$householdId/transactions/route.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/route.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   return (
-    <div className="h-[calc(100dvh-2.5rem)] min-h-0 min-w-0 overflow-hidden">
+    <div className="h-[calc(var(--safe-viewport-height)-2.5rem)] min-h-0 min-w-0 overflow-hidden">
       <div className="mx-auto flex h-full min-h-0 w-full max-w-5xl min-w-0 flex-col overflow-hidden p-4">
         <Outlet />
       </div>

--- a/web/src/routes/_user/household/new.tsx
+++ b/web/src/routes/_user/household/new.tsx
@@ -81,7 +81,7 @@ function getLocaleDisplayName(locale: string, currencyCode: string): string {
 
 function RouteComponent() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
+    <div className="flex min-h-[var(--safe-viewport-height)] flex-col items-center justify-center gap-4 p-4">
       <NewHouseholdForm />
     </div>
   )

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -34,7 +34,7 @@ function FeatureCard({
 
 function App() {
   return (
-    <div className="bg-background flex min-h-svh flex-col px-6 py-12">
+    <div className="bg-background flex min-h-[var(--safe-viewport-height)] flex-col px-6 py-12">
       <main className="flex flex-1 flex-col items-center justify-center gap-12 text-center">
         {/* Logo and Branding */}
         <div className="flex flex-col items-center gap-6">

--- a/web/src/routes/login.index.tsx
+++ b/web/src/routes/login.index.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/login/')({
 
 function RouteComponent() {
   return (
-    <div className="flex min-h-svh flex-col items-center justify-center gap-10 p-6 md:p-10">
+    <div className="flex min-h-[var(--safe-viewport-height)] flex-col items-center justify-center gap-10 p-6 md:p-10">
       <div className="flex w-full max-w-xs flex-col items-center gap-6">
         <Link to="/" className="flex flex-col items-center gap-4 no-underline">
           <Logo size={96} className="rounded-xl" />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -11,6 +11,15 @@
  * chroma 0.005-0.01 per the Warm-Neutrals Rule. No #000, no #fff.
  */
 :root {
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
+  --viewport-height: 100dvh;
+  --safe-viewport-height: calc(
+    var(--viewport-height) - var(--safe-area-inset-top) -
+      var(--safe-area-inset-bottom)
+  );
   --background: oklch(1 0.002 92); /* Paper White */
   --foreground: oklch(0.145 0.005 92); /* Ink Near-Black */
   --card: oklch(1 0.002 92); /* Paper White */
@@ -98,6 +107,17 @@
   --sidebar-ring: oklch(0.556 0.008 92); /* Ink Mid */
 }
 
+/*
+ * WebKit can initialize dynamic viewport units incorrectly when a Home Screen
+ * app cold-starts. Standalone mode has no browser toolbar, so 100vh is stable;
+ * regular Safari keeps 100dvh so its expanding toolbar is still accounted for.
+ */
+@media (display-mode: standalone) {
+  :root {
+    --viewport-height: 100vh;
+  }
+}
+
 @theme inline {
   --font-sans: 'Inter Variable', sans-serif;
   --color-sidebar-ring: var(--sidebar-ring);
@@ -154,6 +174,23 @@
   }
   body {
     @apply bg-background text-foreground relative font-sans;
+    min-height: var(--viewport-height);
+    padding: var(--safe-area-inset-top) var(--safe-area-inset-right)
+      var(--safe-area-inset-bottom) var(--safe-area-inset-left);
+  }
+  body::after {
+    position: fixed;
+    z-index: 100;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: var(--safe-area-inset-bottom);
+    background: var(--background);
+    pointer-events: none;
+    content: '';
+  }
+  #app {
+    min-height: var(--safe-viewport-height);
   }
   html {
     @apply font-sans;


### PR DESCRIPTION
## Summary

- enable iOS safe-area insets and reserve unsafe screen edges globally
- use stable `100vh` sizing for standalone PWA cold starts while keeping `100dvh` in Safari
- keep the mobile action dock above the home indicator with additional breathing room
- apply safe viewport sizing to full-height routes

## Testing

- `cd web && pnpm test` (80 tests)
- `cd web && pnpm check`
- `cd web && pnpm build`

Physical iPhone Home Screen verification is still recommended after deployment.