### PR TITLE
Polish investment and account forms

### DIFF
--- a/web/src/routes/_user/household/$householdId/accounts/-components/account-type-picker.tsx
+++ b/web/src/routes/_user/household/$householdId/accounts/-components/account-type-picker.tsx
@@ -75,13 +75,12 @@ export function AccountTypePicker({
           onBlur()
         }
       }}
-      orientation="vertical"
       variant="outline"
-      spacing={0}
+      spacing={2}
       aria-labelledby={labelledBy}
       aria-describedby={describedBy}
       aria-invalid={invalid}
-      className="w-full"
+      className="grid w-full grid-cols-1 items-stretch sm:grid-cols-2"
     >
       {ACCOUNT_TYPE_LIST.map((type) => {
         const {
@@ -95,11 +94,11 @@ export function AccountTypePicker({
             key={type}
             value={type}
             aria-invalid={invalid}
-            className="aria-pressed:bg-muted aria-pressed:hover:bg-muted aria-pressed:outline-foreground/40 h-auto min-h-12 w-full justify-start gap-3 px-3 py-2 text-left whitespace-normal aria-pressed:outline-1 aria-pressed:-outline-offset-1 aria-pressed:outline-solid"
+            className="aria-pressed:bg-muted aria-pressed:hover:bg-muted aria-pressed:outline-foreground/40 h-full min-h-16 w-full justify-start gap-2.5 px-3 py-2 text-left whitespace-normal aria-pressed:outline-1 aria-pressed:-outline-offset-1 aria-pressed:outline-solid"
           >
             <span
               aria-hidden="true"
-              className="bg-muted ring-foreground/10 grid size-8 shrink-0 place-items-center ring-1"
+              className="bg-muted ring-foreground/10 grid size-8 shrink-0 place-items-center rounded-lg ring-1"
             >
               <Icon className={iconClassName} />
             </span>

--- a/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentCryptoQuoteFragment.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentCryptoQuoteFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<03824b7df8a91c4c67e1e2d167eb2a9f>>
+ * @generated SignedSource<<e686032142540eb7c4cc60bd8e223763>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type newInvestmentCryptoQuoteFragment$data = {
-  readonly cryptoQuote: {
+  readonly cryptoQuote?: {
     readonly currency: string;
     readonly currentPrice: string;
     readonly exchange: string;
@@ -30,6 +30,11 @@ import newInvestmentCryptoQuoteQuery_graphql from './newInvestmentCryptoQuoteQue
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
+      "defaultValue": true,
+      "kind": "LocalArgument",
+      "name": "skipQuote"
+    },
+    {
       "defaultValue": "",
       "kind": "LocalArgument",
       "name": "symbol"
@@ -46,62 +51,69 @@ const node: ReaderFragment = {
   "name": "newInvestmentCryptoQuoteFragment",
   "selections": [
     {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "symbol",
-          "variableName": "symbol"
-        }
-      ],
-      "concreteType": "CryptoQuoteResult",
-      "kind": "LinkedField",
-      "name": "cryptoQuote",
-      "plural": false,
+      "condition": "skipQuote",
+      "kind": "Condition",
+      "passingValue": false,
       "selections": [
         {
           "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "currentPrice",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "symbol",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "exchange",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "currency",
+          "args": [
+            {
+              "kind": "Variable",
+              "name": "symbol",
+              "variableName": "symbol"
+            }
+          ],
+          "concreteType": "CryptoQuoteResult",
+          "kind": "LinkedField",
+          "name": "cryptoQuote",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "currentPrice",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "symbol",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "exchange",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "name",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "currency",
+              "storageKey": null
+            }
+          ],
           "storageKey": null
         }
-      ],
-      "storageKey": null
+      ]
     }
   ],
   "type": "Query",
   "abstractKey": null
 };
 
-(node as any).hash = "317789480b4494719fff3e26c736976b";
+(node as any).hash = "e564c7815c5d038f347f6c5cfe678b91";
 
 export default node;

--- a/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentCryptoQuoteQuery.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentCryptoQuoteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9ffd175ca9c2c66dff54ba3fe05cda81>>
+ * @generated SignedSource<<51918d9d9c63d4315db89db10665b4db>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type newInvestmentCryptoQuoteQuery$variables = {
+  skipQuote?: boolean | null | undefined;
   symbol?: string | null | undefined;
 };
 export type newInvestmentCryptoQuoteQuery$data = {
@@ -24,18 +25,21 @@ export type newInvestmentCryptoQuoteQuery = {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
+    "defaultValue": true,
+    "kind": "LocalArgument",
+    "name": "skipQuote"
+  },
+  {
     "defaultValue": "",
     "kind": "LocalArgument",
     "name": "symbol"
   }
 ],
-v1 = [
-  {
-    "kind": "Variable",
-    "name": "symbol",
-    "variableName": "symbol"
-  }
-];
+v1 = {
+  "kind": "Variable",
+  "name": "symbol",
+  "variableName": "symbol"
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -44,7 +48,14 @@ return {
     "name": "newInvestmentCryptoQuoteQuery",
     "selections": [
       {
-        "args": (v1/*: any*/),
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "skipQuote",
+            "variableName": "skipQuote"
+          },
+          (v1/*: any*/)
+        ],
         "kind": "FragmentSpread",
         "name": "newInvestmentCryptoQuoteFragment"
       }
@@ -59,64 +70,73 @@ return {
     "name": "newInvestmentCryptoQuoteQuery",
     "selections": [
       {
-        "alias": null,
-        "args": (v1/*: any*/),
-        "concreteType": "CryptoQuoteResult",
-        "kind": "LinkedField",
-        "name": "cryptoQuote",
-        "plural": false,
+        "condition": "skipQuote",
+        "kind": "Condition",
+        "passingValue": false,
         "selections": [
           {
             "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "currentPrice",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "symbol",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "exchange",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "currency",
+            "args": [
+              (v1/*: any*/)
+            ],
+            "concreteType": "CryptoQuoteResult",
+            "kind": "LinkedField",
+            "name": "cryptoQuote",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "currentPrice",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "symbol",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "exchange",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "currency",
+                "storageKey": null
+              }
+            ],
             "storageKey": null
           }
-        ],
-        "storageKey": null
+        ]
       }
     ]
   },
   "params": {
-    "cacheID": "639b1a74e079640558d8757cefb6a081",
+    "cacheID": "c648e020e619e116dedae3cea0762716",
     "id": null,
     "metadata": {},
     "name": "newInvestmentCryptoQuoteQuery",
     "operationKind": "query",
-    "text": "query newInvestmentCryptoQuoteQuery(\n  $symbol: String = \"\"\n) {\n  ...newInvestmentCryptoQuoteFragment_3astM6\n}\n\nfragment newInvestmentCryptoQuoteFragment_3astM6 on Query {\n  cryptoQuote(symbol: $symbol) {\n    currentPrice\n    symbol\n    exchange\n    name\n    currency\n  }\n}\n"
+    "text": "query newInvestmentCryptoQuoteQuery(\n  $skipQuote: Boolean = true\n  $symbol: String = \"\"\n) {\n  ...newInvestmentCryptoQuoteFragment_4moOa4\n}\n\nfragment newInvestmentCryptoQuoteFragment_4moOa4 on Query {\n  cryptoQuote(symbol: $symbol) @skip(if: $skipQuote) {\n    currentPrice\n    symbol\n    exchange\n    name\n    currency\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "317789480b4494719fff3e26c736976b";
+(node as any).hash = "e564c7815c5d038f347f6c5cfe678b91";
 
 export default node;

--- a/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentFragment.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0d7ff8d6805aeddbc9ca0754a56ad370>>
+ * @generated SignedSource<<96e988a4807e1a9d3e4dac031595a714>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,17 +15,9 @@ export type newInvestmentFragment$data = {
   readonly accounts: {
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly householdCurrency: {
-          readonly code: string;
-        };
-        readonly icon: string | null | undefined;
         readonly id: string;
-        readonly name: string;
         readonly type: AccountType;
-        readonly user: {
-          readonly name: string;
-        };
-        readonly value: string;
+        readonly " $fragmentSpreads": FragmentRefs<"transactionAccountPickerFragment">;
       } | null | undefined;
     } | null | undefined> | null | undefined;
   };
@@ -36,15 +28,7 @@ export type newInvestmentFragment$key = {
   readonly " $fragmentSpreads": FragmentRefs<"newInvestmentFragment">;
 };
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-};
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [
     {
       "defaultValue": null,
@@ -111,50 +95,70 @@ return {
                   "name": "type",
                   "storageKey": null
                 },
-                (v0/*: any*/),
                 {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "icon",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "value",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "HouseholdCurrency",
-                  "kind": "LinkedField",
-                  "name": "householdCurrency",
-                  "plural": false,
+                  "kind": "InlineDataFragmentSpread",
+                  "name": "transactionAccountPickerFragment",
                   "selections": [
                     {
                       "alias": null,
                       "args": null,
                       "kind": "ScalarField",
-                      "name": "code",
+                      "name": "name",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "icon",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "balance",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "HouseholdCurrency",
+                      "kind": "LinkedField",
+                      "name": "householdCurrency",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "code",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Transaction",
+                      "kind": "LinkedField",
+                      "name": "latestTransaction",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "datetime",
+                          "storageKey": null
+                        }
+                      ],
                       "storageKey": null
                     }
                   ],
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
                   "args": null,
-                  "concreteType": "User",
-                  "kind": "LinkedField",
-                  "name": "user",
-                  "plural": false,
-                  "selections": [
-                    (v0/*: any*/)
-                  ],
-                  "storageKey": null
+                  "argumentDefinitions": []
                 }
               ],
               "storageKey": null
@@ -169,8 +173,7 @@ return {
   "type": "Household",
   "abstractKey": null
 };
-})();
 
-(node as any).hash = "3b7ba133bbef9b5bcb790b02eacbe4f2";
+(node as any).hash = "71b722e0007ba9aa5c2202c003d1de79";
 
 export default node;

--- a/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentStockQuoteFragment.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentStockQuoteFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2b1c56b7afe3bed8836406156c1e6e89>>
+ * @generated SignedSource<<0480255f4d6a602b5fd95b59a1ab3de3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type newInvestmentStockQuoteFragment$data = {
-  readonly stockQuote: {
+  readonly stockQuote?: {
     readonly currency: string;
     readonly currentPrice: string;
     readonly exchange: string;
@@ -30,6 +30,11 @@ import newInvestmentStockQuoteQuery_graphql from './newInvestmentStockQuoteQuery
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
+      "defaultValue": true,
+      "kind": "LocalArgument",
+      "name": "skipQuote"
+    },
+    {
       "defaultValue": "",
       "kind": "LocalArgument",
       "name": "symbol"
@@ -46,62 +51,69 @@ const node: ReaderFragment = {
   "name": "newInvestmentStockQuoteFragment",
   "selections": [
     {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Variable",
-          "name": "symbol",
-          "variableName": "symbol"
-        }
-      ],
-      "concreteType": "StockQuoteResult",
-      "kind": "LinkedField",
-      "name": "stockQuote",
-      "plural": false,
+      "condition": "skipQuote",
+      "kind": "Condition",
+      "passingValue": false,
       "selections": [
         {
           "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "currentPrice",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "symbol",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "exchange",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "currency",
+          "args": [
+            {
+              "kind": "Variable",
+              "name": "symbol",
+              "variableName": "symbol"
+            }
+          ],
+          "concreteType": "StockQuoteResult",
+          "kind": "LinkedField",
+          "name": "stockQuote",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "currentPrice",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "symbol",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "exchange",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "name",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "currency",
+              "storageKey": null
+            }
+          ],
           "storageKey": null
         }
-      ],
-      "storageKey": null
+      ]
     }
   ],
   "type": "Query",
   "abstractKey": null
 };
 
-(node as any).hash = "b0e75f93e89ead741191522dd816a989";
+(node as any).hash = "9688bc2218e2e2c6981404e83a42ada3";
 
 export default node;

--- a/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentStockQuoteQuery.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/investments/-components/__generated__/newInvestmentStockQuoteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a63c6b652c58df72c1f559067e3f7f6d>>
+ * @generated SignedSource<<557ac263ac5a115c4680d6d80153af61>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type newInvestmentStockQuoteQuery$variables = {
+  skipQuote?: boolean | null | undefined;
   symbol?: string | null | undefined;
 };
 export type newInvestmentStockQuoteQuery$data = {
@@ -24,18 +25,21 @@ export type newInvestmentStockQuoteQuery = {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
+    "defaultValue": true,
+    "kind": "LocalArgument",
+    "name": "skipQuote"
+  },
+  {
     "defaultValue": "",
     "kind": "LocalArgument",
     "name": "symbol"
   }
 ],
-v1 = [
-  {
-    "kind": "Variable",
-    "name": "symbol",
-    "variableName": "symbol"
-  }
-];
+v1 = {
+  "kind": "Variable",
+  "name": "symbol",
+  "variableName": "symbol"
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -44,7 +48,14 @@ return {
     "name": "newInvestmentStockQuoteQuery",
     "selections": [
       {
-        "args": (v1/*: any*/),
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "skipQuote",
+            "variableName": "skipQuote"
+          },
+          (v1/*: any*/)
+        ],
         "kind": "FragmentSpread",
         "name": "newInvestmentStockQuoteFragment"
       }
@@ -59,64 +70,73 @@ return {
     "name": "newInvestmentStockQuoteQuery",
     "selections": [
       {
-        "alias": null,
-        "args": (v1/*: any*/),
-        "concreteType": "StockQuoteResult",
-        "kind": "LinkedField",
-        "name": "stockQuote",
-        "plural": false,
+        "condition": "skipQuote",
+        "kind": "Condition",
+        "passingValue": false,
         "selections": [
           {
             "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "currentPrice",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "symbol",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "exchange",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "currency",
+            "args": [
+              (v1/*: any*/)
+            ],
+            "concreteType": "StockQuoteResult",
+            "kind": "LinkedField",
+            "name": "stockQuote",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "currentPrice",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "symbol",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "exchange",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "currency",
+                "storageKey": null
+              }
+            ],
             "storageKey": null
           }
-        ],
-        "storageKey": null
+        ]
       }
     ]
   },
   "params": {
-    "cacheID": "2d9554a0e3142673134cdb0f12932b3c",
+    "cacheID": "96693b6678b5d1a56ee8b6c35c417f5d",
     "id": null,
     "metadata": {},
     "name": "newInvestmentStockQuoteQuery",
     "operationKind": "query",
-    "text": "query newInvestmentStockQuoteQuery(\n  $symbol: String = \"\"\n) {\n  ...newInvestmentStockQuoteFragment_3astM6\n}\n\nfragment newInvestmentStockQuoteFragment_3astM6 on Query {\n  stockQuote(symbol: $symbol) {\n    currentPrice\n    symbol\n    exchange\n    name\n    currency\n  }\n}\n"
+    "text": "query newInvestmentStockQuoteQuery(\n  $skipQuote: Boolean = true\n  $symbol: String = \"\"\n) {\n  ...newInvestmentStockQuoteFragment_4moOa4\n}\n\nfragment newInvestmentStockQuoteFragment_4moOa4 on Query {\n  stockQuote(symbol: $symbol) @skip(if: $skipQuote) {\n    currentPrice\n    symbol\n    exchange\n    name\n    currency\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b0e75f93e89ead741191522dd816a989";
+(node as any).hash = "9688bc2218e2e2c6981404e83a42ada3";
 
 export default node;

--- a/web/src/routes/_user/household/$householdId/investments/-components/new-investment.tsx
+++ b/web/src/routes/_user/household/$householdId/investments/-components/new-investment.tsx
@@ -3,10 +3,10 @@ import { useForm } from '@tanstack/react-form'
 import { toast } from 'sonner'
 import * as z from 'zod'
 import { useFragment, useMutation, useRefetchableFragment } from 'react-relay'
-import { capitalize } from 'lodash-es'
 import invariant from 'tiny-invariant'
 import { match } from 'ts-pattern'
 import { useNavigate } from '@tanstack/react-router'
+import { BitcoinIcon, ChartNoAxesCombinedIcon, CheckIcon } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -26,14 +26,6 @@ import {
 } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-} from '@/components/ui/combobox'
-import {
   Item,
   ItemContent,
   ItemDescription,
@@ -47,11 +39,7 @@ import { commitMutationResult } from '@/lib/relay'
 import { type newInvestmentMutation } from './__generated__/newInvestmentMutation.graphql'
 import { newInvestmentFragment$key } from './__generated__/newInvestmentFragment.graphql'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import {
-  getLogoTickerURL,
-  getLogoCryptoURL,
-  getLogoDomainURL,
-} from '@/lib/logo'
+import { getLogoTickerURL, getLogoCryptoURL } from '@/lib/logo'
 import { useCurrency } from '@/hooks/use-currency'
 import { cn } from '@/lib/utils'
 import { useEffect, useState, useTransition } from 'react'
@@ -59,6 +47,30 @@ import { Spinner } from '@/components/ui/spinner'
 import { newInvestmentStockQuoteFragment$key } from './__generated__/newInvestmentStockQuoteFragment.graphql'
 import { newInvestmentCryptoQuoteFragment$key } from './__generated__/newInvestmentCryptoQuoteFragment.graphql'
 import { useDisplayCurrency } from '@/hooks/use-display-currency'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { TransactionAccountPicker } from '../../transactions/-components/transaction-account-picker'
+
+type InvestmentType = (typeof INVESTMENT_TYPE_LIST)[number]
+
+const INVESTMENT_TYPE_PRESENTATION = {
+  stock: {
+    label: 'Stock',
+    description: 'Shares, funds, and exchange-traded assets',
+    icon: ChartNoAxesCombinedIcon,
+  },
+  crypto: {
+    label: 'Crypto',
+    description: 'Cryptocurrencies and digital assets',
+    icon: BitcoinIcon,
+  },
+} satisfies Record<
+  InvestmentType,
+  { label: string; description: string; icon: typeof BitcoinIcon }
+>
+
+function isInvestmentType(value: string | undefined): value is InvestmentType {
+  return INVESTMENT_TYPE_LIST.some((type) => type === value)
+}
 
 const formSchema = z.object({
   name: z
@@ -83,15 +95,7 @@ const newInvestmentFragment = graphql`
         node {
           id
           type
-          name
-          icon
-          value
-          householdCurrency {
-            code
-          }
-          user {
-            name
-          }
+          ...transactionAccountPickerFragment
         }
       }
     }
@@ -101,8 +105,11 @@ const newInvestmentFragment = graphql`
 const newInvestmentStockQuoteFragment = graphql`
   fragment newInvestmentStockQuoteFragment on Query
   @refetchable(queryName: "newInvestmentStockQuoteQuery")
-  @argumentDefinitions(symbol: { type: "String", defaultValue: "" }) {
-    stockQuote(symbol: $symbol) {
+  @argumentDefinitions(
+    symbol: { type: "String", defaultValue: "" }
+    skipQuote: { type: "Boolean", defaultValue: true }
+  ) {
+    stockQuote(symbol: $symbol) @skip(if: $skipQuote) {
       currentPrice
       symbol
       exchange
@@ -115,8 +122,11 @@ const newInvestmentStockQuoteFragment = graphql`
 const newInvestmentCryptoQuoteFragment = graphql`
   fragment newInvestmentCryptoQuoteFragment on Query
   @refetchable(queryName: "newInvestmentCryptoQuoteQuery")
-  @argumentDefinitions(symbol: { type: "String", defaultValue: "" }) {
-    cryptoQuote(symbol: $symbol) {
+  @argumentDefinitions(
+    symbol: { type: "String", defaultValue: "" }
+    skipQuote: { type: "Boolean", defaultValue: true }
+  ) {
+    cryptoQuote(symbol: $symbol) @skip(if: $skipQuote) {
       currentPrice
       symbol
       exchange
@@ -172,7 +182,7 @@ export function NewInvestment({
 
   const { displayCurrencyCode } = useDisplayCurrency()
 
-  const { formatCurrency, formatCurrencyWithPrivacyMode } = useCurrency()
+  const { formatCurrency } = useCurrency()
 
   const [commitMutation, isMutationInFlight] =
     useMutation<newInvestmentMutation>(newInvestmentMutation)
@@ -300,72 +310,16 @@ export function NewInvestment({
                 return (
                   <Field data-invalid={isInvalid}>
                     <FieldLabel htmlFor={field.name}>Account</FieldLabel>
-                    <Combobox
-                      items={investmentAccounts.map((account) => account.id)}
-                      itemToStringLabel={(item) =>
-                        investmentAccounts.find((acc) => acc.id === item)
-                          ?.name || ''
-                      }
+                    <TransactionAccountPicker
+                      accounts={investmentAccounts}
+                      name={field.name}
+                      label="Account"
                       value={field.state.value}
-                      onValueChange={(value) => {
-                        field.handleChange(value || '')
-                      }}
-                    >
-                      <ComboboxInput
-                        data-1p-ignore
-                        id={field.name}
-                        name={field.name}
-                        placeholder="Select an account"
-                        onBlur={field.handleBlur}
-                        aria-invalid={isInvalid}
-                      />
-                      <ComboboxContent>
-                        <ComboboxEmpty>No items found.</ComboboxEmpty>
-                        <ComboboxList>
-                          {(item: string) => {
-                            const account = investmentAccounts.find(
-                              (acc) => acc.id === item,
-                            )
-                            if (!account) return null
-                            return (
-                              <ComboboxItem key={item} value={item}>
-                                <Item size="xs" className="p-0">
-                                  <ItemMedia variant="image">
-                                    <Avatar className="size-6">
-                                      <AvatarImage
-                                        src={getLogoDomainURL(
-                                          account.icon || '',
-                                        )}
-                                        alt={account.icon || 'unknown logo'}
-                                      />
-                                      <AvatarFallback>
-                                        {account.name}
-                                      </AvatarFallback>
-                                    </Avatar>
-                                  </ItemMedia>
-                                  <ItemContent>
-                                    <ItemTitle>{account.name}</ItemTitle>
-                                    <ItemDescription>
-                                      <span className="tabular-nums">
-                                        {formatCurrencyWithPrivacyMode({
-                                          value: account.value,
-                                          currencyCode:
-                                            account.householdCurrency.code,
-                                          liability:
-                                            account.type === 'liability',
-                                        })}
-                                      </span>
-                                      <span aria-hidden="true"> · </span>
-                                      {account.user.name}
-                                    </ItemDescription>
-                                  </ItemContent>
-                                </Item>
-                              </ComboboxItem>
-                            )
-                          }}
-                        </ComboboxList>
-                      </ComboboxContent>
-                    </Combobox>
+                      onValueChange={field.handleChange}
+                      onBlur={field.handleBlur}
+                      invalid={isInvalid}
+                      preferredTypes={['investment']}
+                    />
                     {isInvalid && (
                       <FieldError errors={field.state.meta.errors} />
                     )}
@@ -388,35 +342,67 @@ export function NewInvestment({
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
                   <Field data-invalid={isInvalid}>
-                    <FieldLabel htmlFor={field.name}>Type</FieldLabel>
-                    <Combobox
-                      items={INVESTMENT_TYPE_LIST}
-                      value={field.state.value}
-                      onValueChange={(value) => field.handleChange(value || '')}
+                    <FieldLabel id={`${field.name}-label`}>Type</FieldLabel>
+                    <ToggleGroup
+                      value={
+                        isInvestmentType(field.state.value)
+                          ? [field.state.value]
+                          : []
+                      }
+                      onValueChange={(values) => {
+                        const nextValue = values[0]
+                        if (isInvestmentType(nextValue)) {
+                          field.handleChange(nextValue)
+                        }
+                      }}
+                      onBlur={(event) => {
+                        if (
+                          !event.currentTarget.contains(event.relatedTarget)
+                        ) {
+                          field.handleBlur()
+                        }
+                      }}
+                      variant="outline"
+                      spacing={2}
+                      aria-labelledby={`${field.name}-label`}
+                      aria-invalid={isInvalid}
+                      className="grid w-full grid-cols-2 items-stretch"
                     >
-                      <ComboboxInput
-                        id={field.name}
-                        name={field.name}
-                        placeholder="Select a type"
-                        onBlur={field.handleBlur}
-                        aria-invalid={isInvalid}
-                        className="*:capitalize"
-                      />
-                      <ComboboxContent>
-                        <ComboboxEmpty>No items found.</ComboboxEmpty>
-                        <ComboboxList className="">
-                          {(item: string) => (
-                            <ComboboxItem
-                              key={item}
-                              value={item}
-                              className="flex flex-col items-start gap-0"
+                      {INVESTMENT_TYPE_LIST.map((type) => {
+                        const {
+                          label,
+                          description,
+                          icon: Icon,
+                        } = INVESTMENT_TYPE_PRESENTATION[type]
+                        return (
+                          <ToggleGroupItem
+                            key={type}
+                            value={type}
+                            aria-invalid={isInvalid}
+                            className="aria-pressed:bg-muted aria-pressed:hover:bg-muted aria-pressed:outline-foreground/40 h-full min-h-16 w-full justify-start gap-2.5 px-3 py-2 text-left whitespace-normal aria-pressed:outline-1 aria-pressed:-outline-offset-1 aria-pressed:outline-solid"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="bg-muted ring-foreground/10 grid size-8 shrink-0 place-items-center rounded-lg ring-1"
                             >
-                              <span className="">{capitalize(item)}</span>
-                            </ComboboxItem>
-                          )}
-                        </ComboboxList>
-                      </ComboboxContent>
-                    </Combobox>
+                              <Icon className="size-4" />
+                            </span>
+                            <span className="min-w-0 flex-1">
+                              <span className="block text-xs/relaxed font-semibold">
+                                {label}
+                              </span>
+                              <span className="text-muted-foreground block text-xs/normal font-normal">
+                                {description}
+                              </span>
+                            </span>
+                            <CheckIcon
+                              aria-hidden="true"
+                              className="shrink-0 opacity-0 group-aria-pressed/toggle:opacity-100"
+                            />
+                          </ToggleGroupItem>
+                        )
+                      })}
+                    </ToggleGroup>
                     {isInvalid && (
                       <FieldError errors={field.state.meta.errors} />
                     )}
@@ -465,12 +451,14 @@ export function NewInvestment({
                 onChange: ({ value, fieldApi }) => {
                   startTransition(() => {
                     setQueriedSymbol(value)
+                    if (!value) return
+
                     const investmentType = fieldApi.form.getFieldValue('type')
 
                     if (investmentType === 'crypto') {
-                      refetchCryptoQuote({ symbol: value })
+                      refetchCryptoQuote({ symbol: value, skipQuote: false })
                     } else {
-                      refetchStockQuote({ symbol: value })
+                      refetchStockQuote({ symbol: value, skipQuote: false })
                     }
                   })
                 },

--- a/web/src/routes/_user/household/$householdId/investments/__generated__/newInvestmentQuery.graphql.ts
+++ b/web/src/routes/_user/household/$householdId/investments/__generated__/newInvestmentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a88ce957be90ba7d16724ac49c32f9a9>>
+ * @generated SignedSource<<260b57a50a211dce96313807f123ce27>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -38,52 +38,7 @@ v1 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v3 = [
-  {
-    "kind": "Literal",
-    "name": "symbol",
-    "value": ""
-  }
-],
-v4 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "currentPrice",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "symbol",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "exchange",
-    "storageKey": null
-  },
-  (v2/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "currency",
-    "storageKey": null
-  }
-];
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -190,7 +145,13 @@ return {
                         "name": "type",
                         "storageKey": null
                       },
-                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -202,7 +163,7 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "value",
+                        "name": "balance",
                         "storageKey": null
                       },
                       {
@@ -227,12 +188,18 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "User",
+                        "concreteType": "Transaction",
                         "kind": "LinkedField",
-                        "name": "user",
+                        "name": "latestTransaction",
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "datetime",
+                            "storageKey": null
+                          },
                           (v1/*: any*/)
                         ],
                         "storageKey": null
@@ -249,36 +216,16 @@ return {
           (v1/*: any*/)
         ],
         "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": (v3/*: any*/),
-        "concreteType": "StockQuoteResult",
-        "kind": "LinkedField",
-        "name": "stockQuote",
-        "plural": false,
-        "selections": (v4/*: any*/),
-        "storageKey": "stockQuote(symbol:\"\")"
-      },
-      {
-        "alias": null,
-        "args": (v3/*: any*/),
-        "concreteType": "CryptoQuoteResult",
-        "kind": "LinkedField",
-        "name": "cryptoQuote",
-        "plural": false,
-        "selections": (v4/*: any*/),
-        "storageKey": "cryptoQuote(symbol:\"\")"
       }
     ]
   },
   "params": {
-    "cacheID": "1d810242ad5cef50ed0a107d8e491352",
+    "cacheID": "39b1d53648b454acf9c71f26d1708a31",
     "id": null,
     "metadata": {},
     "name": "newInvestmentQuery",
     "operationKind": "query",
-    "text": "query newInvestmentQuery(\n  $viewUserIds: [ID!]\n) {\n  household {\n    ...newInvestmentFragment_3rIbPZ\n    id\n  }\n  ...newInvestmentStockQuoteFragment\n  ...newInvestmentCryptoQuoteFragment\n}\n\nfragment newInvestmentCryptoQuoteFragment on Query {\n  cryptoQuote(symbol: \"\") {\n    currentPrice\n    symbol\n    exchange\n    name\n    currency\n  }\n}\n\nfragment newInvestmentFragment_3rIbPZ on Household {\n  accounts(where: {archived: false, userIDIn: $viewUserIds}) {\n    edges {\n      node {\n        id\n        type\n        name\n        icon\n        value\n        householdCurrency {\n          code\n          id\n        }\n        user {\n          name\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment newInvestmentStockQuoteFragment on Query {\n  stockQuote(symbol: \"\") {\n    currentPrice\n    symbol\n    exchange\n    name\n    currency\n  }\n}\n"
+    "text": "query newInvestmentQuery(\n  $viewUserIds: [ID!]\n) {\n  household {\n    ...newInvestmentFragment_3rIbPZ\n    id\n  }\n}\n\nfragment newInvestmentFragment_3rIbPZ on Household {\n  accounts(where: {archived: false, userIDIn: $viewUserIds}) {\n    edges {\n      node {\n        id\n        type\n        ...transactionAccountPickerFragment\n      }\n    }\n  }\n}\n\nfragment transactionAccountPickerFragment on Account {\n  name\n  icon\n  balance\n  householdCurrency {\n    code\n    id\n  }\n  latestTransaction {\n    datetime\n    id\n  }\n}\n"
   }
 };
 })();

--- a/web/src/routes/_user/household/$householdId/transactions/new.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/new.tsx
@@ -81,7 +81,7 @@ function RouteComponent() {
 
   return (
     <div className="flex h-full min-h-0 w-full overflow-hidden">
-      <Item className="h-full min-h-0 overflow-hidden rounded-none border-0 p-0">
+      <Item className="h-full min-h-0 overflow-hidden rounded-xl border-0 p-0 [&_[data-slot=card]]:!rounded-b-xl">
         <LogTransaction fragmentRef={data.household} />
       </Item>
     </div>


### PR DESCRIPTION
## Summary
- round the mobile log-transaction form card
- defer stock and crypto quote lookups until a symbol is entered
- reuse the responsive account selection drawer/popover for new investments
- replace investment and account type dropdown/segments with responsive selection cards
- keep account type cards equal-height and switch narrow layouts to four full-width rows

## Verification
- pnpm check
- pnpm test -- --run (80 tests)
- pnpm build
- pnpm relay-compiler
- browser QA on mobile transaction, new investment, account drawer, and narrow new-account layouts