### PR TITLE
Fix mobile viewport and action dock containment

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -10,7 +10,6 @@
     <meta name="description" content="beavermoney.app" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="shortcut icon" href="/favicon.ico" />

--- a/web/src/components/app-action-dock.tsx
+++ b/web/src/components/app-action-dock.tsx
@@ -38,10 +38,10 @@ export function AppActionDock({
   }
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-40 md:hidden">
+    <div className="bg-background z-40 shrink-0 px-4 pt-2 pb-4 md:hidden">
       <nav
         aria-label="Quick actions"
-        className="liquid-glass-chrome pointer-events-auto mx-auto grid h-16 w-[min(calc(100%-2rem),26rem)] grid-cols-[1fr_1.15fr_1fr] gap-1 overflow-hidden rounded-[1.25rem] p-1.5"
+        className="liquid-glass-chrome mx-auto grid h-16 w-full max-w-[26rem] grid-cols-[1fr_1.15fr_1fr] gap-1 overflow-hidden rounded-[1.25rem] p-1.5"
       >
         <DropdownMenu>
           <DropdownMenuTrigger
@@ -118,8 +118,4 @@ export function AppActionDock({
       </nav>
     </div>
   )
-}
-
-export function MobileActionDockSpacer() {
-  return <div aria-hidden="true" className="h-24 shrink-0 md:hidden" />
 }

--- a/web/src/components/app-action-dock.tsx
+++ b/web/src/components/app-action-dock.tsx
@@ -38,7 +38,7 @@ export function AppActionDock({
   }
 
   return (
-    <div className="pointer-events-none fixed right-[var(--safe-area-inset-right)] bottom-[calc(var(--safe-area-inset-bottom)+1rem)] left-[var(--safe-area-inset-left)] z-40 md:hidden">
+    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-40 md:hidden">
       <nav
         aria-label="Quick actions"
         className="liquid-glass-chrome pointer-events-auto mx-auto grid h-16 w-[min(calc(100%-2rem),26rem)] grid-cols-[1fr_1.15fr_1fr] gap-1 overflow-hidden rounded-[1.25rem] p-1.5"
@@ -121,10 +121,5 @@ export function AppActionDock({
 }
 
 export function MobileActionDockSpacer() {
-  return (
-    <div
-      aria-hidden="true"
-      className="h-[calc(6rem+var(--safe-area-inset-bottom))] shrink-0 md:hidden"
-    />
-  )
+  return <div aria-hidden="true" className="h-24 shrink-0 md:hidden" />
 }

--- a/web/src/components/layouts/household-content-layout.tsx
+++ b/web/src/components/layouts/household-content-layout.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react'
 
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { MobileActionDockSpacer } from '@/components/app-action-dock'
 import { cn } from '@/lib/utils'
 
 interface HouseholdContentLayoutProps {
@@ -14,11 +13,8 @@ function HouseholdContentLayout({
   className,
 }: HouseholdContentLayoutProps) {
   return (
-    <ScrollArea className="h-full min-h-0 overflow-y-auto">
-      <div className={cn('mx-auto max-w-5xl p-4', className)}>
-        {children}
-        <MobileActionDockSpacer />
-      </div>
+    <ScrollArea className="h-full min-h-0 overflow-hidden [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden">
+      <div className={cn('mx-auto max-w-5xl p-4', className)}>{children}</div>
     </ScrollArea>
   )
 }

--- a/web/src/routes/_user/household/$householdId/route.tsx
+++ b/web/src/routes/_user/household/$householdId/route.tsx
@@ -239,9 +239,9 @@ function RouteComponent() {
             <DisplayCurrencyProvider householdRef={data.household}>
               <Hotkeys />
               <CommandMenu />
-              <SidebarProvider className="h-dvh min-h-0 overflow-hidden">
+              <SidebarProvider className="h-dvh min-h-0 min-w-0 overflow-hidden">
                 <AppSidebar fragmentRef={data} />
-                <SidebarInset className="h-dvh min-h-0 overflow-hidden md:h-[calc(100dvh-1rem)]">
+                <SidebarInset className="h-dvh min-h-0 min-w-0 overflow-hidden md:h-[calc(100dvh-1rem)]">
                   <header className="liquid-glass-chrome z-30 mx-2 mt-2 flex h-11 shrink-0 items-center rounded-xl p-1 transition-[width,height] duration-200 ease-[var(--ease-out-quint)]">
                     <SidebarTrigger className="cursor-pointer" />
                     <div className="flex flex-1 items-center px-3">
@@ -338,7 +338,7 @@ function RouteComponent() {
                       </Button>
                     </div>
                   </header>
-                  <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                  <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
                     <Outlet />
                   </div>
                   <AppActionDock

--- a/web/src/routes/_user/household/$householdId/route.tsx
+++ b/web/src/routes/_user/household/$householdId/route.tsx
@@ -239,9 +239,9 @@ function RouteComponent() {
             <DisplayCurrencyProvider householdRef={data.household}>
               <Hotkeys />
               <CommandMenu />
-              <SidebarProvider className="h-[var(--safe-viewport-height)] min-h-0 overflow-hidden">
+              <SidebarProvider className="h-dvh min-h-0 overflow-hidden">
                 <AppSidebar fragmentRef={data} />
-                <SidebarInset className="h-[var(--safe-viewport-height)] min-h-0 overflow-hidden md:h-[calc(var(--safe-viewport-height)-1rem)]">
+                <SidebarInset className="h-dvh min-h-0 overflow-hidden md:h-[calc(100dvh-1rem)]">
                   <header className="liquid-glass-chrome z-30 mx-2 mt-2 flex h-11 shrink-0 items-center rounded-xl p-1 transition-[width,height] duration-200 ease-[var(--ease-out-quint)]">
                     <SidebarTrigger className="cursor-pointer" />
                     <div className="flex flex-1 items-center px-3">

--- a/web/src/routes/_user/household/$householdId/transactions/-components/log-transaction.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/log-transaction.tsx
@@ -17,7 +17,6 @@ import { focusInitialTransactionControl } from './transaction-focus'
 import { useLogTransaction } from '@/hooks/use-log-transaction'
 import type { LogTransactionType } from '@/hooks/log-transaction-store'
 import { cn } from '@/lib/utils'
-import { MobileActionDockSpacer } from '@/components/app-action-dock'
 
 const logTransactionFragment = graphql`
   fragment logTransactionFragment on Household
@@ -155,14 +154,13 @@ export function LogTransaction({ fragmentRef }: NewTransactionProps) {
         </ScrollArea>
       </div>
 
-      <ScrollArea className="min-h-0 w-full flex-1 [&_[data-slot=scroll-area-viewport]]:overscroll-contain">
+      <ScrollArea className="min-h-0 w-full flex-1 overflow-hidden [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden [&_[data-slot=scroll-area-viewport]]:overscroll-contain">
         {selectedType === 'expense' && <NewExpense fragmentRef={data} />}
         {selectedType === 'income' && <NewIncome fragmentRef={data} />}
         {selectedType === 'transfer' && <NewTransfer fragmentRef={data} />}
         {selectedType === 'buy' && <NewBuy fragmentRef={data} />}
         {selectedType === 'sell' && <NewSell fragmentRef={data} />}
         {selectedType === 'move' && <NewMove fragmentRef={data} />}
-        <MobileActionDockSpacer />
       </ScrollArea>
     </Item>
   )

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-card.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-card.tsx
@@ -96,7 +96,7 @@ export function TransactionCard({
       onPointerEnter={() => onPreload(data.id)}
       onFocus={() => onPreload(data.id)}
       onClick={() => onPreload(data.id)}
-      className="group/item focus-visible:border-primary focus-visible:ring-primary/25 bg-background flex w-full flex-wrap items-center rounded-none border-0 text-xs/relaxed outline-none focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset"
+      className="group/item border-border focus-visible:border-primary focus-visible:ring-primary/25 bg-background hover:border-primary/45 flex w-full flex-wrap items-center overflow-hidden rounded-lg border text-xs/relaxed transition-colors duration-150 outline-none focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset"
     >
       {sortedItems.map((item, index) =>
         item.type === 'lot' ? (

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
@@ -52,7 +52,6 @@ import {
 import { TransactionDialogPreview } from './transaction-dialog-preview'
 import type { transactionDialogPreviewFragment$key } from './__generated__/transactionDialogPreviewFragment.graphql'
 import { useHouseholdViewScope } from '@/hooks/use-household-view-scope'
-import { MobileActionDockSpacer } from '@/components/app-action-dock'
 
 const transactionsListFragment = graphql`
   fragment transactionsListFragment on Household
@@ -248,14 +247,14 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
       onPreloadTransaction={preloadTransaction}
     />
   ) : (
-    <ScrollArea className="min-h-0 min-w-0 flex-1">
+    <ScrollArea className="min-h-0 min-w-0 flex-1 overflow-hidden [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden">
       <div className="min-w-0 pr-2">
         {groups.map((group) => (
           <Fragment key={group.date.toISOString()}>
             <div className="text-muted-foreground px-1 pt-3 pb-1.5 text-xs/relaxed font-medium tracking-[0.02em] first:pt-0">
               {formatDateHeader(group.date)}
             </div>
-            <ItemGroup className="divide-border has-[[data-slot=item]:hover]:border-primary/45 gap-0 divide-y overflow-hidden rounded-lg border transition-colors duration-150">
+            <ItemGroup className="gap-2">
               {group.transactions.map((transaction) => (
                 <TransactionCard
                   key={transaction.id}
@@ -283,7 +282,6 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
           </div>
         )}
         <div ref={ref}></div>
-        <MobileActionDockSpacer />
       </div>
     </ScrollArea>
   )

--- a/web/src/routes/_user/household/$householdId/transactions/route.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/route.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   return (
-    <div className="h-[calc(var(--safe-viewport-height)-2.5rem)] min-h-0 min-w-0 overflow-hidden">
+    <div className="h-[calc(100dvh-2.5rem)] min-h-0 min-w-0 overflow-hidden">
       <div className="mx-auto flex h-full min-h-0 w-full max-w-5xl min-w-0 flex-col overflow-hidden p-4">
         <Outlet />
       </div>

--- a/web/src/routes/_user/household/$householdId/transactions/route.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/route.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   return (
-    <div className="h-[calc(100dvh-2.5rem)] min-h-0 min-w-0 overflow-hidden">
+    <div className="h-full min-h-0 min-w-0 overflow-hidden">
       <div className="mx-auto flex h-full min-h-0 w-full max-w-5xl min-w-0 flex-col overflow-hidden p-4">
         <Outlet />
       </div>

--- a/web/src/routes/_user/household/new.tsx
+++ b/web/src/routes/_user/household/new.tsx
@@ -81,7 +81,7 @@ function getLocaleDisplayName(locale: string, currencyCode: string): string {
 
 function RouteComponent() {
   return (
-    <div className="flex min-h-[var(--safe-viewport-height)] flex-col items-center justify-center gap-4 p-4">
+    <div className="flex min-h-dvh flex-col items-center justify-center gap-4 p-4">
       <NewHouseholdForm />
     </div>
   )

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -34,7 +34,7 @@ function FeatureCard({
 
 function App() {
   return (
-    <div className="bg-background flex min-h-[var(--safe-viewport-height)] flex-col px-6 py-12">
+    <div className="bg-background flex min-h-dvh flex-col px-6 py-12">
       <main className="flex flex-1 flex-col items-center justify-center gap-12 text-center">
         {/* Logo and Branding */}
         <div className="flex flex-col items-center gap-6">

--- a/web/src/routes/login.index.tsx
+++ b/web/src/routes/login.index.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/login/')({
 
 function RouteComponent() {
   return (
-    <div className="flex min-h-[var(--safe-viewport-height)] flex-col items-center justify-center gap-10 p-6 md:p-10">
+    <div className="flex min-h-dvh flex-col items-center justify-center gap-10 p-6 md:p-10">
       <div className="flex w-full max-w-xs flex-col items-center gap-6">
         <Link to="/" className="flex flex-col items-center gap-4 no-underline">
           <Logo size={96} className="rounded-xl" />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -11,15 +11,6 @@
  * rounded, translucent chrome system inspired by iOS material layering.
  */
 :root {
-  --safe-area-inset-top: env(safe-area-inset-top, 0px);
-  --safe-area-inset-right: env(safe-area-inset-right, 0px);
-  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
-  --safe-area-inset-left: env(safe-area-inset-left, 0px);
-  --viewport-height: 100dvh;
-  --safe-viewport-height: calc(
-    var(--viewport-height) - var(--safe-area-inset-top) -
-      var(--safe-area-inset-bottom)
-  );
   --background: oklch(1 0.002 92); /* Paper White */
   --foreground: oklch(0.145 0.005 92); /* Ink Near-Black */
   --card: oklch(1 0.002 92); /* Paper White */
@@ -120,17 +111,6 @@
   --sidebar-ring: oklch(0.556 0.008 92); /* Ink Mid */
 }
 
-/*
- * WebKit can initialize dynamic viewport units incorrectly when a Home Screen
- * app cold-starts. Standalone mode has no browser toolbar, so 100vh is stable;
- * regular Safari keeps 100dvh so its expanding toolbar is still accounted for.
- */
-@media (display-mode: standalone) {
-  :root {
-    --viewport-height: 100vh;
-  }
-}
-
 @theme inline {
   --font-sans: 'Inter Variable', sans-serif;
   --color-sidebar-ring: var(--sidebar-ring);
@@ -187,23 +167,6 @@
   }
   body {
     @apply bg-background text-foreground relative font-sans;
-    min-height: var(--viewport-height);
-    padding: var(--safe-area-inset-top) var(--safe-area-inset-right)
-      var(--safe-area-inset-bottom) var(--safe-area-inset-left);
-  }
-  body::after {
-    position: fixed;
-    z-index: 100;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    height: var(--safe-area-inset-bottom);
-    background: var(--background);
-    pointer-events: none;
-    content: '';
-  }
-  #app {
-    min-height: var(--safe-viewport-height);
   }
   html {
     @apply font-sans;


### PR DESCRIPTION
## Summary
- remove obsolete iOS safe-area padding while retaining full-screen PWA support
- return the mobile action dock to normal layout flow so content never scrolls behind it
- constrain household pages to component-level scrolling with horizontal overflow clipped
- render same-day transactions as independent rounded cards

## Verification
- undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "check" not found
-  (80 tests)
- undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "build" not found
- browser QA on mobile transactions, accounts, and new transaction routes