### PR TITLE
fix(web): keep mobile picker headers visible

### DIFF
--- a/web/src/components/mobile-selection-drawer.tsx
+++ b/web/src/components/mobile-selection-drawer.tsx
@@ -90,7 +90,7 @@ export function MobileSelectionDrawer<T>({
         )}
         <ChevronDownIcon className="size-4 shrink-0" aria-hidden="true" />
       </DrawerTrigger>
-      <DrawerContent className="h-[min(70svh,36rem)]">
+      <DrawerContent className="h-[min(55dvh,28rem)]">
         <DrawerHeader className="text-left">
           <DrawerTitle>Select {label.toLowerCase()}</DrawerTitle>
           <DrawerDescription>

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.test.tsx
@@ -144,7 +144,7 @@ it('opens a searchable account drawer on mobile', async () => {
   expect(await screen.findByRole('dialog')).toBeTruthy()
   expect(
     document.querySelector('[data-slot="drawer-popup"]')?.className,
-  ).toContain('h-[min(70svh,36rem)]')
+  ).toContain('h-[min(55dvh,28rem)]')
 
   fireEvent.change(screen.getByRole('combobox', { name: 'Search account' }), {
     target: { value: 'Account 1' },


### PR DESCRIPTION
## Summary
- reduce mobile category and account picker drawer height
- use the dynamic viewport so the drawer responds to keyboard-driven viewport changes
- keep long option lists scrollable while preserving the drawer title and search field

## Verification
- `pnpm exec vitest run src/routes/_user/household/\$householdId/transactions/-components/transaction-account-picker.test.tsx`
- `pnpm check`
- verified at 390x844 and keyboard-sized 390x540 viewports