### PR TITLE
Fix mobile transaction scroll containment

### DIFF
--- a/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transactions-list.tsx
@@ -247,7 +247,7 @@ export function TransactionsList({ fragmentRef }: TransactionsListProps) {
       onPreloadTransaction={preloadTransaction}
     />
   ) : (
-    <ScrollArea className="min-h-0 min-w-0 flex-1 overflow-hidden [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden">
+    <ScrollArea className="min-h-0 min-w-0 flex-1 overflow-hidden [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden [&_[data-slot=scroll-area-viewport]]:overscroll-contain">
       <div className="min-w-0 pr-2">
         {groups.map((group) => (
           <Fragment key={group.date.toISOString()}>

--- a/web/src/routes/_user/household/$householdId/transactions/route.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/route.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   return (
-    <div className="h-full min-h-0 min-w-0 overflow-hidden">
+    <div className="h-full min-h-0 min-w-0 overflow-hidden overscroll-none">
       <div className="mx-auto flex h-full min-h-0 w-full max-w-5xl min-w-0 flex-col overflow-hidden p-4">
         <Outlet />
       </div>


### PR DESCRIPTION
## Summary
- contain touch overscroll within the mobile transaction list
- prevent scroll chaining from reaching the Transactions route/page
- keep the transaction summary and date filter fixed while the list scrolls

## Validation
- `pnpm test --run src/routes/_user/household/$householdId/transactions/-components/transactions-list.test.tsx`
- `pnpm check`