### PR TITLE
Fix mobile transaction detail layout shift

### DIFF
--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.test.tsx
@@ -79,6 +79,13 @@ it('renders normalized transaction data while editing controls load', () => {
   expect(screen.getByText('Date')).toBeTruthy()
   expect(screen.getByText('Category')).toBeTruthy()
   expect(screen.getByText('Options')).toBeTruthy()
+
+  const categorySkeleton = screen
+    .getByText('Category')
+    .closest('[data-slot="transaction-dialog-preview-field"]')
+    ?.querySelector('[data-slot="skeleton"]')
+  expect(categorySkeleton?.className).toContain('h-11')
+  expect(categorySkeleton?.className).toContain('md:h-9')
 })
 
 it('masks cached financial values in privacy mode', () => {

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.tsx
@@ -236,7 +236,7 @@ export function TransactionDialogPreview({
           <FieldGroup>
             <PreviewField label="Description" />
             <PreviewField label="Date" />
-            <PreviewField label="Category" controlClassName="h-9" />
+            <PreviewField label="Category" controlClassName="h-11 md:h-9" />
             <FieldSet data-slot="transaction-dialog-preview-field">
               <FieldLegend variant="label">Options</FieldLegend>
               <FieldGroup data-slot="checkbox-group">


### PR DESCRIPTION
## Summary
- match the transaction detail Category skeleton to the mobile picker height
- preserve the existing desktop skeleton height
- add a regression assertion for both responsive heights

## Validation
- `pnpm test --run src/routes/_user/household/$householdId/transactions/-components/transaction-dialog-preview.test.tsx`
- `pnpm check`