### PR TITLE
Shorten mobile selection drawers

### DIFF
--- a/web/src/components/mobile-selection-drawer.tsx
+++ b/web/src/components/mobile-selection-drawer.tsx
@@ -90,7 +90,7 @@ export function MobileSelectionDrawer<T>({
         )}
         <ChevronDownIcon className="size-4 shrink-0" aria-hidden="true" />
       </DrawerTrigger>
-      <DrawerContent className="h-[min(55dvh,28rem)]">
+      <DrawerContent className="h-[min(45dvh,24rem)]">
         <DrawerHeader className="text-left">
           <DrawerTitle>Select {label.toLowerCase()}</DrawerTitle>
           <DrawerDescription>

--- a/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.test.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/transaction-account-picker.test.tsx
@@ -144,7 +144,7 @@ it('opens a searchable account drawer on mobile', async () => {
   expect(await screen.findByRole('dialog')).toBeTruthy()
   expect(
     document.querySelector('[data-slot="drawer-popup"]')?.className,
-  ).toContain('h-[min(55dvh,28rem)]')
+  ).toContain('h-[min(45dvh,24rem)]')
 
   fireEvent.change(screen.getByRole('combobox', { name: 'Search account' }), {
     target: { value: 'Account 1' },


### PR DESCRIPTION
## Summary
- reduce the shared mobile selector drawer height from 55dvh/28rem to 45dvh/24rem
- keep account and category option lists scrollable within the shorter drawer
- update the account picker height assertion

## Verification
- focused account and category picker tests (6 passed)
- Prettier and diff checks
- visual verification at a 390x844 mobile viewport