### PR TITLE
Round shared mobile content bottom corners

### DIFF
--- a/web/src/routes/_user/household/$householdId/route.tsx
+++ b/web/src/routes/_user/household/$householdId/route.tsx
@@ -338,7 +338,7 @@ function RouteComponent() {
                       </Button>
                     </div>
                   </header>
-                  <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+                  <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-b-2xl">
                     <Outlet />
                   </div>
                   <AppActionDock


### PR DESCRIPTION
## Summary
- round both lower corners of the shared household content outlet
- apply the clipping consistently across all household pages, not only Accounts

## Validation
- `pnpm --dir web check`
- `pnpm --dir web test --run`
- verified 18px lower-corner radii at a 393x852 viewport on Accounts and Transactions