### PR TITLE
Round inset mobile content corners

### DIFF
--- a/web/src/routes/_user/household/$householdId/route.tsx
+++ b/web/src/routes/_user/household/$householdId/route.tsx
@@ -338,7 +338,7 @@ function RouteComponent() {
                       </Button>
                     </div>
                   </header>
-                  <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-b-2xl">
+                  <div className="mobile-content-bottom-corners relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
                     <Outlet />
                   </div>
                   <AppActionDock

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -237,6 +237,37 @@
   box-shadow: 0 1px 2px var(--surface-shadow-color);
 }
 
+@media (max-width: 47.999rem) {
+  .mobile-content-bottom-corners::before,
+  .mobile-content-bottom-corners::after {
+    position: absolute;
+    z-index: 20;
+    bottom: 0;
+    width: var(--radius-2xl);
+    height: var(--radius-2xl);
+    pointer-events: none;
+    content: '';
+  }
+
+  .mobile-content-bottom-corners::before {
+    left: 1rem;
+    background: radial-gradient(
+      circle at top right,
+      transparent calc(var(--radius-2xl) - 0.5px),
+      var(--background) var(--radius-2xl)
+    );
+  }
+
+  .mobile-content-bottom-corners::after {
+    right: 1rem;
+    background: radial-gradient(
+      circle at top left,
+      transparent calc(var(--radius-2xl) - 0.5px),
+      var(--background) var(--radius-2xl)
+    );
+  }
+}
+
 [data-slot='button'][data-variant='default'] {
   box-shadow:
     inset 0 1px 0 oklch(1 0.002 92 / 38%),


### PR DESCRIPTION
## Summary
- replace the ineffective full-width shell radius with lower-corner masks aligned to the shared 16px content gutter
- apply the visible rounded dock boundary across every household page
- preserve the full-width scroll viewport and scrollbar

## Validation
- `pnpm --dir web check`
- `pnpm --dir web test --run`
- visually verified both inset corner arcs at a 393px mobile viewport