### PR TITLE
Fix investment share input and total calculation

### DIFF
--- a/web/src/components/currency-input.test.tsx
+++ b/web/src/components/currency-input.test.tsx
@@ -37,3 +37,92 @@ it('parses locale decimal separators before reporting the numeric value', () => 
     value: '12,34',
   })
 })
+
+it('reflects external value changes while preserving user edits', () => {
+  const onValueChange = vi.fn()
+  const { rerender } = render(
+    <CurrencyInput
+      locale="en-US"
+      currency="USD"
+      value={undefined}
+      onValueChange={onValueChange}
+    />,
+  )
+
+  rerender(
+    <CurrencyInput
+      locale="en-US"
+      currency="USD"
+      value={25}
+      onValueChange={onValueChange}
+    />,
+  )
+
+  expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('25')
+
+  fireEvent.change(screen.getByRole('textbox'), {
+    target: { value: '27.50' },
+  })
+
+  rerender(
+    <CurrencyInput
+      locale="en-US"
+      currency="USD"
+      value={27.5}
+      onValueChange={onValueChange}
+    />,
+  )
+
+  expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('27.50')
+  expect(onValueChange).toHaveBeenLastCalledWith({
+    floatValue: 27.5,
+    value: '27.50',
+  })
+})
+
+it('can hide the currency symbol for non-currency decimal values', () => {
+  const { container } = render(
+    <CurrencyInput
+      locale="en-US"
+      currency="USD"
+      value={10.5}
+      showCurrencySymbol={false}
+      onValueChange={() => {}}
+    />,
+  )
+
+  expect(container.textContent).not.toContain('$')
+  expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('10.5')
+})
+
+it('keeps a controlled zero visible for fractional entry', () => {
+  const onValueChange = vi.fn()
+  const { rerender } = render(
+    <CurrencyInput
+      locale="en-US"
+      currency="USD"
+      value={undefined}
+      onValueChange={onValueChange}
+    />,
+  )
+
+  rerender(
+    <CurrencyInput
+      locale="en-US"
+      currency="USD"
+      value={0}
+      onValueChange={onValueChange}
+    />,
+  )
+
+  expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('0')
+
+  fireEvent.change(screen.getByRole('textbox'), {
+    target: { value: '0.5' },
+  })
+
+  expect(onValueChange).toHaveBeenLastCalledWith({
+    floatValue: 0.5,
+    value: '0.5',
+  })
+})

--- a/web/src/components/currency-input.tsx
+++ b/web/src/components/currency-input.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib/utils'
 import { controlGroupSurfaceClassName } from '@/components/ui/control-surface'
-import { useState, useCallback, type ComponentPropsWithoutRef } from 'react'
+import { useCallback, useState, type ComponentPropsWithoutRef } from 'react'
 import { useCurrencyConfig } from '@/hooks/use-currency-config'
 
 type CurrencyInputProps = Omit<
@@ -12,14 +12,22 @@ type CurrencyInputProps = Omit<
   value?: string | number
   decimalScale?: number
   allowNegative?: boolean
+  showCurrencySymbol?: boolean
   onValueChange?: (values: { floatValue?: number; value: string }) => void
 }
 
-function valueToRaw(value: string | number | undefined): string {
+function valueToRaw(
+  value: string | number | undefined,
+  decimalSeparator: string,
+): string {
   if (value == null) return ''
   if (typeof value === 'string') return value
-  if (value === 0) return ''
-  return String(value)
+  return String(value).replace('.', decimalSeparator)
+}
+
+function rawToFloat(raw: string, decimalSeparator: string) {
+  const parsed = parseFloat(raw.replace(decimalSeparator, '.'))
+  return Number.isNaN(parsed) ? undefined : parsed
 }
 
 export function CurrencyInput({
@@ -28,6 +36,7 @@ export function CurrencyInput({
   currency,
   decimalScale = 2,
   allowNegative = false,
+  showCurrencySymbol = true,
   onValueChange,
   value,
   ...props
@@ -37,7 +46,22 @@ export function CurrencyInput({
     currency,
   )
 
-  const [rawValue, setRawValue] = useState(() => valueToRaw(value))
+  const [rawValue, setRawValue] = useState(() =>
+    valueToRaw(value, decimalSeparator),
+  )
+  const [lastValue, setLastValue] = useState(value)
+
+  if (!Object.is(value, lastValue)) {
+    const nextRawValue = valueToRaw(value, decimalSeparator)
+    setLastValue(value)
+
+    if (
+      rawToFloat(rawValue, decimalSeparator) !==
+      rawToFloat(nextRawValue, decimalSeparator)
+    ) {
+      setRawValue(nextRawValue)
+    }
+  }
 
   const validate = useCallback(
     (raw: string): string => {
@@ -75,9 +99,7 @@ export function CurrencyInput({
       const cleaned = validate(e.target.value)
       setRawValue(cleaned)
 
-      const normalizedValue = cleaned.replace(decimalSeparator, '.')
-      const floatValue =
-        cleaned === '' ? undefined : parseFloat(normalizedValue)
+      const floatValue = rawToFloat(cleaned, decimalSeparator)
       onValueChange?.({ floatValue, value: cleaned })
     },
     [decimalSeparator, validate, onValueChange],
@@ -91,7 +113,7 @@ export function CurrencyInput({
         className,
       )}
     >
-      {prefix && (
+      {showCurrencySymbol && prefix && (
         <span className="text-muted-foreground pr-1 pl-2 text-sm select-none md:text-xs/relaxed">
           {prefix}
         </span>
@@ -104,12 +126,12 @@ export function CurrencyInput({
         onChange={handleChange}
         className={cn(
           'min-w-0 flex-1 border-none bg-transparent px-0 py-0.5 text-sm outline-none md:text-xs/relaxed',
-          !prefix && 'pl-2',
-          !suffix && 'pr-2',
+          (!showCurrencySymbol || !prefix) && 'pl-2',
+          (!showCurrencySymbol || !suffix) && 'pr-2',
         )}
         {...props}
       />
-      {suffix && (
+      {showCurrencySymbol && suffix && (
         <span className="text-muted-foreground pr-2 pl-1 text-sm select-none md:text-xs/relaxed">
           {suffix}
         </span>

--- a/web/src/routes/_user/household/$householdId/transactions/-components/new-buy.tsx
+++ b/web/src/routes/_user/household/$householdId/transactions/-components/new-buy.tsx
@@ -315,17 +315,21 @@ export function NewBuy({ fragmentRef }: NewBuyProps) {
                 return (
                   <Field data-invalid={isInvalid}>
                     <FieldLabel htmlFor={field.name}>Shares</FieldLabel>
-                    <Input
+                    <CurrencyInput
                       data-1p-ignore
                       id={field.name}
                       name={field.name}
-                      type="number"
-                      step="any"
-                      value={field.state.value || ''}
+                      value={field.state.value}
+                      locale={household.locale}
+                      currency={
+                        selectedAccount?.householdCurrency.code ??
+                        displayCurrencyCode
+                      }
+                      decimalScale={8}
+                      showCurrencySymbol={false}
                       onBlur={field.handleBlur}
-                      onChange={(e) => {
-                        const val = parseFloat(e.target.value)
-                        field.handleChange(isNaN(val) ? 0 : val)
+                      onValueChange={(values) => {
+                        field.handleChange(values.floatValue!)
                       }}
                       aria-invalid={isInvalid}
                       placeholder="10"


### PR DESCRIPTION
## Summary
- reuse the shared decimal input for investment shares without a currency symbol
- sync programmatic currency input values so calculated totals are visible and remain editable
- cover external updates, trailing zeros, hidden symbols, and fractional entry with regression tests

## Verification
- `pnpm test` (82 tests)
- targeted ESLint
- `pnpm exec tsc --noEmit`
- browser verified shares `2.5` × price `$10` prefills total `$25`, then accepts manual `$24.5` override