### PR TITLE
Fix field spacing when popovers open

### DIFF
--- a/web/src/components/ui/field.tsx
+++ b/web/src/components/ui/field.tsx
@@ -132,7 +132,7 @@ function FieldDescription({ className, ...props }: React.ComponentProps<'p'>) {
       data-slot="field-description"
       className={cn(
         'text-muted-foreground text-left text-xs/relaxed leading-normal font-normal group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5',
-        'last:mt-0 nth-last-2:-mt-1',
+        'last:mt-0 [&:nth-last-child(2_of_[data-slot])]:-mt-1',
         '[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
         className,
       )}


### PR DESCRIPTION
## Summary
- keep FieldDescription spacing stable when Base UI inserts popover focus guards
- count only meaningful data-slot children for the compact second-to-last spacing rule

## Verification
- pnpm check
- pnpm test --run src/routes/_user/household/$householdId/transactions/-components/transaction-investment-picker.test.tsx
- verified closed and expanded dropdown spacing in the local preview